### PR TITLE
fixed typo by removing unvalid comma in subdue option

### DIFF
--- a/0.9/checks.md
+++ b/0.9/checks.md
@@ -148,7 +148,7 @@ which is flexible enough to handle different zones and format.
       "interval": 60,
       "subdue": {
         "begin": "5PM PST",
-        "end": "9AM PST",
+        "end": "9AM PST"
       }
     }
   }


### PR DESCRIPTION
Before 

```
"subdue": {
  "begin": "5PM PST",
  "end": "9AM PST",
}
```

But that causes an unvalid json, so I have changed it to

```
"subdue": {
  "begin": "5PM PST",
  "end": "9AM PST"
}
```
