### PR TITLE
Layout

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -11,6 +11,7 @@
     <link href="/css/bootstrap.css" rel="stylesheet">
     <link href="/css/bootstrap-responsive.css" rel="stylesheet">
     <link href="/css/neet.css" rel="stylesheet">
+    <link href="/css/docs.css" rel="stylesheet">
 
     <!-- LOAD GOOGLE WEBFONTS -->
     <link href='http://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,700italic,300,400,600,700' rel='stylesheet' type='text/css'>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -6,24 +6,19 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Sensu, a monitoring framework that aims to be simple, malleable, and scalable.">
     <meta name="author" content="Heavy Water Operations, LLC.">
+    <!-- LOAD CSS  -->
+    <link href="/css/font-awesome.css" rel="stylesheet">
+    <link href="/css/bootstrap.css" rel="stylesheet">
+    <link href="/css/bootstrap-responsive.css" rel="stylesheet">
+    <link href="/css/neet.css" rel="stylesheet">
 
-        <!-- LOAD CSS  -->
+    <!-- LOAD GOOGLE WEBFONTS -->
+    <link href='http://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,700italic,300,400,600,700' rel='stylesheet' type='text/css'>
 
-        <link rel="stylesheet" type="text/css" href="/css/style.css" />
-        <link href="/css/font-awesome.css" rel="stylesheet">
-        <link href="/css/bootstrap.css" rel="stylesheet">
-        <link href="/css/bootstrap-responsive.css" rel="stylesheet">
-        <link href="/css/neet.css" rel="stylesheet">
-        <link href="/css/pygment.css" rel="stylesheet">
-
-        <!-- LOAD GOOGLE WEBFONTS -->
-
-        <link href='http://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,700italic,300,400,600,700' rel='stylesheet' type='text/css'>
-
-        <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
-        <!--[if lt IE 9]>
-        <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-        <![endif]-->
+    <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
+    <!--[if lt IE 9]>
+    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+    <![endif]-->
 
     <!-- Le fav and touch icons -->
     <link rel="shortcut icon" href="/ico/favicon.ico">
@@ -34,7 +29,6 @@
   </head>
 
   <body>
-
     <div class="navbar navbar-fixed-top">
       <div class="navbar-inner">
         <div class="container">
@@ -83,13 +77,10 @@
 
     <div class="container">
     <br />
-
         {{content}}
-
     </div>
 
     <br />
-    </div> <!-- not sure what this closing tag belongs to... -ch -->
 
     <div class="footer_sec">
       <footer>
@@ -98,20 +89,8 @@
         </div>
       </footer>
     </div>
-
-    <!-- Le javascript
-    ================================================== -->
-    <!-- Placed at the end of the document so the pages load faster -->
-    <script src="/js/bootstrap.js" type="text/javascript"></script>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.js" type="text/javascript"></script>
-    <script src="/js/jquery.gallery.js" type="text/javascript"></script>
-    <script src="/js/modernizr.custom.53451.js" type="text/javascript"></script>
-    <script type="text/javascript">
-      $(function() {
-        $('#dg-container').gallery();
-      });
-    </script/>
-
+    <script src="/js/bootstrap.js" type="text/javascript"></script>
     <script type="text/javascript">
       var _gauges = _gauges || [];
       (function() {
@@ -127,4 +106,3 @@
     </script>
   </body>
 </html>
-

--- a/css/docs.css
+++ b/css/docs.css
@@ -1,0 +1,24 @@
+body {
+  font-size: 14px;
+}
+
+h1 {
+    font-size: 1.8em;
+}
+
+h2 {
+    font-size: 1.5em;
+    padding-top: 1.2em;
+    margin: 1em 0 1em;
+    border-top: 2px solid #ddd;
+}
+
+h3 {
+    font-size: 1em;
+    margin: 2em 0 1.5em;
+}
+
+p {
+    line-height:1.5em;
+    padding-bottom: 0.2em;
+}


### PR DESCRIPTION
This removes some unused js/css carried over from the theme.  JQuery has to be included before bootstrap.  I left jsquery and bootstrap in for use in docs but fixed the order so it didn't throw a JS error.

Styling updates for better readability as seen below.

Before Styling:
![screen shot 2013-06-06 at 9 05 27 pm](https://f.cloud.github.com/assets/242283/621771/d81c0ee2-cf16-11e2-8331-3220e7dbc5e8.png)

After Styling:
![screen shot 2013-06-06 at 9 05 04 pm](https://f.cloud.github.com/assets/242283/621770/d7ed2186-cf16-11e2-932b-0c8914b85fb2.png)
