### PR TITLE
Changed the command used for email handler

### DIFF
--- a/source/docs/0.11/handlers.md
+++ b/source/docs/0.11/handlers.md
@@ -54,7 +54,7 @@ Here is an example that uses a `mail` to email the event data.
   "handlers": {
     "mail": {
       "type": "pipe",
-      "command": "mail -s 'sensu event' email@address.com"
+      "command": "echo $(cat) > /tmp/mail.txt; mail -s 'sensu event' email@address.com < /tmp/mail.txt" 
     }
   }
 }

--- a/source/docs/0.11/handlers.md
+++ b/source/docs/0.11/handlers.md
@@ -54,7 +54,7 @@ Here is an example that uses a `mail` to email the event data.
   "handlers": {
     "mail": {
       "type": "pipe",
-      "command": "echo $(cat) > /tmp/mail.txt; mail -s 'sensu event' email@address.com < /tmp/mail.txt" 
+      "command": "mail -s 'sensu event' email@address.com"
     }
   }
 }

--- a/source/docs/0.11/handlers.md
+++ b/source/docs/0.11/handlers.md
@@ -59,7 +59,12 @@ Here is an example that uses a `mail` to email the event data.
   }
 }
 ```
+Note: If you are using a GNU flavour of Linux (e.g. Ubuntu) the default mail command may not send the event data in the e-mail body. To e-mail out the json event data using shell commands it may be necessary to install bsd-mailx overwriting the default GNU mail command:
+``` shell
+sudo apt-get install bsd-mailx
+```
 
+ 
 #### Handler configuration
 
 Handlers using the `sensu-plugin` Rubygem have access to Sensu configs

--- a/source/docs/0.12/handlers.md
+++ b/source/docs/0.12/handlers.md
@@ -55,7 +55,7 @@ Here is an example that uses a `mail` to email the event data.
   "handlers": {
     "mail": {
       "type": "pipe",
-      "command": "mail -s 'sensu event' email@address.com"
+      "command": "echo $(cat) > /tmp/mail.txt; mail -s 'sensu event' email@address.com < /tmp/mail.txt" 
     }
   }
 }

--- a/source/docs/0.12/handlers.md
+++ b/source/docs/0.12/handlers.md
@@ -55,7 +55,7 @@ Here is an example that uses a `mail` to email the event data.
   "handlers": {
     "mail": {
       "type": "pipe",
-      "command": "echo $(cat) > /tmp/mail.txt; mail -s 'sensu event' email@address.com < /tmp/mail.txt" 
+      "command": "mail -s 'sensu event' email@address.com"
     }
   }
 }

--- a/source/docs/0.12/handlers.md
+++ b/source/docs/0.12/handlers.md
@@ -60,6 +60,10 @@ Here is an example that uses a `mail` to email the event data.
   }
 }
 ```
+Note: If you are using a GNU flavour of Linux (e.g. Ubuntu) the default mail command may not send the event data in the e-mail body. To e-mail out the json event data using shell commands it may be necessary to install bsd-mailx overwriting the default GNU mail command:
+``` shell
+sudo apt-get install bsd-mailx
+```
 
 #### Handler configuration
 


### PR DESCRIPTION
Sensu has to read the json data from stdin so the command in the doc
pre this commit will simply send out a blank e-mail with "sensu alert"
as the subject.

This threw me a little when following the docs and this change is similar to one discussed on irc.
