### PR TITLE
Clean up the check name for mysql-replication.

### DIFF
--- a/source/docs/0.13/checks.md
+++ b/source/docs/0.13/checks.md
@@ -358,7 +358,7 @@ You can also specify a default value if the key does not exist `:::foo.bar|defau
 ~~~ json
 {
   "checks": {
-    "chef_client": {
+    "mysql-replication": {
       "command": "check-mysql-replication.rb --user :::mysql.user::: --password :::mysql.password:::",
       "subscribers": [
         "mysql"


### PR DESCRIPTION
It was listing the check name of chef_client instead of something descriptive for mysql-replication.
