### PR TITLE
Update handlers.md

### DIFF
--- a/source/docs/0.13/handlers.md
+++ b/source/docs/0.13/handlers.md
@@ -159,7 +159,11 @@ Here is an example that publishes event data on an AMQP topic exchange
       "type": "transport",
       "pipe": {
         "type": "topic",
-        "name": "events"
+        "name": "events",
+        "options": {
+          "durable": "true",
+          "passive": "true"
+        }
       }
     }
   }


### PR DESCRIPTION
Adds an example of transport handler configuration options, mainly for AMQP. Commit https://github.com/sensu/sensu/commit/8e6dd5dd75e9d929ef428abb5c72a115685fd909 change the configuration behaviour and add the options Hash for transport specific configuration. In previous versions that options Hash does not exists and the configuration was part of AMQP configuration.
