### PR TITLE
Added localhost 3030 socket documentation

### DIFF
--- a/source/docs/0.13/external_result_input.md
+++ b/source/docs/0.13/external_result_input.md
@@ -1,0 +1,35 @@
+---
+version: "0.13"
+category: "Advanced Topics"
+title: "Inputting External Results to the Local Socket"
+---
+
+# Background
+
+So far, two mechanisms to get Sensu events have been addressed:
+
+* Checks defined and initiated by the Sensu client. (standalone: true).
+* Checks defined on the *server*, that the clients '''subscribe''' to.
+(subscribers: [ 'webservers' ])
+
+There is a third way of getting Sensu event data onto the queue for Sensu
+ handlers to consume: external results sent to the local socket on port 3030.
+
+# Examples
+
+~~~ shell
+echo '{ "name": "my_check", "output": "some output", "status": 0 }' > /dev/tcp/localhost/3030
+~~~
+
+## Real Life Examples
+
+* Joe Miller's [Pantheon Multi-Ping Check](https://gist.github.com/joemiller/5806570)
+* Kyle Anderon's [Sensu Shell Helper](https://github.com/solarkennedy/sensu-shell-helper)
+
+# Notes
+
+* The client name associated with the event will be the client name of the 
+ sensu-client process that is bound to localhost:3030.
+* Attributes like event "action", "occurrences", and "issued" are set server-side, and 
+ cannot be fed into the local socket.
+* Any other user-provided event data *can* be for custom handlers to consume.

--- a/source/docs/0.13/index.md
+++ b/source/docs/0.13/index.md
@@ -49,6 +49,7 @@ hide_toc: true
 
 * **Advanced Topics**
   * [Scaling Strategies](scaling_strategies)
+  * [Inputting External Results to the Local Socket](external_result_input)
 
 * **Formats**
   * [Event Data](event_data)


### PR DESCRIPTION
We use the localhost:3030 socket extensively at my work.
However, when asked about how to interact with it, there is no link I can provide to describe it, or why it would be useful. (I can't find one)

There isn't that much documentation here, but I figured _something_ ought to exist. I'm putting this under advanced topics, because it does take a bit to understand that there are checks that spawn event data as if other checks had ran? In other words, I consider an advanced feature. :)
