### PR TITLE
Add information about the EMBEDDED_RUBY when adding the first check

### DIFF
--- a/source/docs/0.14/adding_a_check.md
+++ b/source/docs/0.14/adding_a_check.md
@@ -33,9 +33,13 @@ We're going to use `check-procs.rb` from the
 repo.
 
 If you have installed Sensu from the omnibus packages you can continue
-to installing the `check-procs.rb` plugin. Otherwise we need to install
-the `sensu-plugin` gem which has various helper classes used by many of
-the community plugins:
+to installing the `check-procs.rb` plugin. You will have to configure
+the Sensu client to use the embedded ruby from the omnibus package by
+setting `EMBEDDED_RUBY=true` in `/etc/default/sensu` and restarting
+the client.
+
+Otherwise we need to install the `sensu-plugin` gem which has various
+helper classes used by many of the community plugins:
 
 ~~~ bash
 gem install sensu-plugin --no-rdoc --no-ri


### PR DESCRIPTION
Hi,

I just started using Sensu a day ago and got confused when I got to the point where the first check is added.
Basically on a vanilla installation using the omnibus package the plugins won't work because they will use the environment ruby. I moved forward by editing the plugin shebang, but then when I was looking for production ready checks I found that all the plugins in the community use the system wide ruby.

Asking in the IRC channel about best practice I got a few answers to put the embedded ruby first in the PATH and that EMBEDDED_RUBY option actually does that. I think it's good to have that information here, because if you are new to Sensu this can be a confusing moment as I have the expectation that using the package will prevent such problems.

I did find that EMBEDDED_RUBY is documented in the FAQ just before updating the documentation, but still think it's proper to mention it here.

I'm very new to the project, so I'm not aware of best practices, workflow, etc so I'm open for suggestions about this PR.
