### PR TITLE
Changes port number of dashboard

### DIFF
--- a/source/docs/0.16/adding_a_check.md
+++ b/source/docs/0.16/adding_a_check.md
@@ -230,5 +230,5 @@ Edit this file on the Sensu server again and add the -w parameter to the command
 
 Restart the sensu-server service.
 
-After about a minute we should see an alert on the sensu-dashboard:
-`http://<SERVER IP>:8080`, and in the `sensu-server.log`.
+After about a minute we should see an alert on the uchiwa dashboard (if installed):
+`http://<SERVER IP>:3000`, and in the `sensu-server.log`.


### PR DESCRIPTION
The dashboard is no longer installed by default. The only recommended dashboard is the uchiwa dashboard, which runs on port 3000 by default.
