### PR TITLE
Document 404 in api /request

### DIFF
--- a/source/docs/0.16/api_checks.md
+++ b/source/docs/0.16/api_checks.md
@@ -79,4 +79,6 @@ Example URL: `http://hostname:4567/checks/chef_client_process`
 
   - malformed: 400
 
+  - missing: 404
+
   - error: 500


### PR DESCRIPTION
The api /request endpoint will send back a 404 if the requested check name is missing.
