### PR TITLE
Fix a bug with the stop block

### DIFF
--- a/source/docs/0.16/extensions.md
+++ b/source/docs/0.16/extensions.md
@@ -66,7 +66,7 @@ module Sensu::Extension
 
     # Called when Sensu begins to shutdown.
     def stop
-      yield
+      true
     end
 
   end


### PR DESCRIPTION
According to the change here sensu/sensu-extension@80af876#diff-e697e281c8361c1600ad5aa581dd8dfaL69 it should not return a yield anymore
