### PR TITLE
Added check documentation for dependencies

### DIFF
--- a/source/docs/0.17/checks.md
+++ b/source/docs/0.17/checks.md
@@ -151,6 +151,18 @@ subscribers
     "subscribers": ["production"]
     ~~~
 
+dependencies
+: description
+  : An array of client_name/check_name values that represent dependencies of the check. If set, handlers will not fire if any of the dependent checks are non-OK.
+: required
+  : false
+: type
+  : Array
+: example
+  : ~~~ shell
+    "dependencies": ["examplehost.domain/example_check", "upstreamhost.domain/other_check"]
+    ~~~
+
 publish
 : description
   : If check requests are published for the check.


### PR DESCRIPTION
Seems to be an undocumented feature of the standard sensu-handler class
https://github.com/sensu-plugins/sensu-plugin/blob/b679e239a63d7c206bada044f67f43834d44e33f/lib/sensu-handler.rb#L148
