### PR TITLE
Added API host "localhost" to installation guide config.json

### DIFF
--- a/source/docs/0.20/files/config.json
+++ b/source/docs/0.20/files/config.json
@@ -9,6 +9,7 @@
     "host": "localhost"
   },
   "api": {
+    "host": "localhost",
     "port": 4567
   }
 }

--- a/source/docs/0.20/install-sensu.md
+++ b/source/docs/0.20/install-sensu.md
@@ -70,7 +70,7 @@ The primary configuration for Sensu is stored in JSON format at `/etc/sensu/conf
 sudo wget -O /etc/sensu/config.json http://sensuapp.org/docs/0.20/files/config.json
 ~~~
 
-_NOTE: this example file configures the RabbitMQ and Redis connection options and the Sensu API port._
+_NOTE: this example file configures the RabbitMQ and Redis connection options and the Sensu API._
 
 ~~~ json
 {
@@ -84,6 +84,7 @@ _NOTE: this example file configures the RabbitMQ and Redis connection options an
     "host": "localhost"
   },
   "api": {
+    "host": "localhost",
     "port": 4567
   }
 }


### PR DESCRIPTION
This allows the `sensu-plugin` handler event filtering (silenced) to work without any changes to the guide configuration.
