### PR TITLE
added sudo for some commands

### DIFF
--- a/source/docs/0.20/install-sensu-client.md
+++ b/source/docs/0.20/install-sensu-client.md
@@ -92,13 +92,13 @@ By default, the Sensu client service does not start on boot. Use the following i
 ## Ubuntu/Debian
 
 ~~~ shell
-update-rc.d sensu-client defaults
+sudo update-rc.d sensu-client defaults
 ~~~
 
 ## CentOS/RHEL
 
 ~~~ shell
-chkconfig sensu-client on
+sudo chkconfig sensu-client on
 ~~~
 
 # Install the Sensu client on remote hosts

--- a/source/docs/0.20/install-sensu.md
+++ b/source/docs/0.20/install-sensu.md
@@ -205,15 +205,15 @@ _NOTE: Only **one** flavor of Sensu should be used at any given time: Sensu Core
 ### Ubuntu/Debian
 
 ~~~ shell
-update-rc.d sensu-server defaults
-update-rc.d sensu-api defaults
+sudo update-rc.d sensu-server defaults
+sudo update-rc.d sensu-api defaults
 ~~~
 
 ### CentOS/RHEL
 
 ~~~ shell
-chkconfig sensu-server on
-chkconfig sensu-api on
+sudo chkconfig sensu-server on
+sudo chkconfig sensu-api on
 ~~~
 
 ## Sensu Enterprise
@@ -221,11 +221,11 @@ chkconfig sensu-api on
 ### Ubuntu/Debian
 
 ~~~ shell
-update-rc.d sensu-enterprise defaults
+sudo update-rc.d sensu-enterprise defaults
 ~~~
 
 ### CentOS/RHEL
 
 ~~~ shell
-chkconfig sensu-enterprise on
+sudo chkconfig sensu-enterprise on
 ~~~


### PR DESCRIPTION
`update-rc.d` and `chkconfig` will fail without `sudo`. Other pages run these commands with `sudo`, but `install-sensu-client.md` and `install-sensu.md` don't.
