### PR TITLE
Added docs for the reconnect_on_error option for RabbitMQ

### DIFF
--- a/source/docs/0.20/rabbitmq.md
+++ b/source/docs/0.20/rabbitmq.md
@@ -129,6 +129,20 @@ ssl
     "ssl": {}
     ~~~
 
+reconnect_on_error
+: description
+  : Reconnect to RabbitMQ in the event of an error.
+: required
+  : false
+: type
+  : Boolean
+: default
+  : `true`
+: example
+  : ~~~ shell
+    "reconnect_on_error": true
+    ~~~
+
 #### SSL attributes
 
 The following attributes are configured within the `"ssl": {}` RabbitMQ definition attribute scope.


### PR DESCRIPTION
This documents the setting here:
https://github.com/sensu/sensu/blob/9b64a7f8f6ca9aa23ad9667c6b41c09d630e05b1/lib/sensu/daemon.rb#L190

I think this is the right place to put it?
In theory it applies to any transport, let me know if you want something in the enterprise docs.
