### PR TITLE
Broken link: Enterprise Dashboard Docs -> Audit Logging

### DIFF
--- a/source/docs/0.20/index.md
+++ b/source/docs/0.20/index.md
@@ -70,6 +70,5 @@ hide_toc: true
 * **Enterprise Dashboard Docs**
   * [Overview](enterprise-dashboard-overview)
   * [Configuration](enterprise-dashboard-configuration)
-  * [Audit Logging](enterprise-dashboard-audit-logging)
   * [Collections](enterprise-dashboard-collections)
   * [HUD](enterprise-dashboard-hud)


### PR DESCRIPTION
- It looks like the Audit Logging info is on the preceding page (Configuration)
- The Configuration page's 'Next' Page skips to Collections

So I'm guessing that Audit Logging isn't needed in the sidebar?  But if you want it broken out on to a new page, please feel free to close this out...
