### PR TITLE
Fix enterprise dashboard overview dashboard missing out of date link

### DIFF
--- a/source/docs/0.20/enterprise-dashboard-collections.md
+++ b/source/docs/0.20/enterprise-dashboard-collections.md
@@ -3,8 +3,8 @@ version: 0.20
 category: "Collections"
 title: "Collections"
 next:
-  url: "enterprise-dashboard-overview-dashboard"
-  text: "Enterprise Dashboard Overview Dashboard"
+  url: "enterprise-dashboard-hud"
+  text: "Enterprise Dashboard HUD"
 ---
 
 ## Collections

--- a/source/docs/0.21/enterprise-dashboard-collections.md
+++ b/source/docs/0.21/enterprise-dashboard-collections.md
@@ -3,8 +3,8 @@ version: 0.21
 category: "Collections"
 title: "Collections"
 next:
-  url: "enterprise-dashboard-overview-dashboard"
-  text: "Enterprise Dashboard Overview Dashboard"
+  url: "enterprise-dashboard-hud"
+  text: "Enterprise Dashboard HUD"
 ---
 
 ## Collections


### PR DESCRIPTION
Hi was looking at the doc and I got this error page.
![notfound](https://cloud.githubusercontent.com/assets/43065/11597100/4ab97a30-9ab1-11e5-867f-7cdf6d0ef6fc.png)

This pull request fixes the two occurrences of the issue I could find
