### PR TITLE
0.23 documentation updates (new features)

### DIFF
--- a/source/docs/0.22/checks.md
+++ b/source/docs/0.22/checks.md
@@ -30,7 +30,7 @@ next:
   - [Check command token specification](#check-command-token-specification)
     - [Command token declaration syntax](#command-token-declaration)
     - [Command token client attributes](#command-token-client-attributes)
-    - [Command token alternate values](#command-token-alternate-values)
+    - [Command token default values](#command-token-default-values)
 - [Check configuration](#check-configuration)
   - [Example check definition](#example-check-definition)
   - [Check definition specification](#check-definition-specification)
@@ -275,22 +275,22 @@ definition attributes][16].
 - `:::disk.warning:::` would be replaced with a [custom attribute][24] called
   `warning` nested inside of a JSON hash called `disk`
 
-#### Command token alternate values
+#### Command token default values
 
-Command token alternate values can be used as a fallback in the event that no a
+Command token default values can be used as a fallback in the event that no a
 [command token client attribute][25] is not provided by the [client
-definition][16]. Command token alternate values are separated by a pipe
-character (`|`), and can be used to provide a "default values" for clients that
+definition][16]. Command token default values are separated by a pipe
+character (`|`), and can be used to provide a "fallback value" for clients that
 are missing the declared token attribute.
 
-##### Examples {#command-token-alternate-values}
+##### Examples {#command-token-default-values}
 
 - `:::url|https://sensuapp.org:::` would be replaced with a [custom
   attribute][24] called `url`. If no such attribute called `url` is included in
-  the client definition, the alternate (or default) value of
+  the client definition, the default (or fallback) value of
   `https://sensuapp.org` will be used.
 
-_NOTE: if a command token alternate value is not provided (i.e. as a default
+_NOTE: if a command token default value is not provided (i.e. as a fallback
 value), and the Sensu client definition does not have a matching [command token
 client attribute][25], a [check result][4] indicating unmatched tokens will be
 published for the check execution (e.g.: `"Unmatched command tokens:

--- a/source/docs/0.23/changelog.md
+++ b/source/docs/0.23/changelog.md
@@ -16,39 +16,69 @@ Source: [GitHub.com](https://github.com/sensu/sensu/blob/master/CHANGELOG.md#023
 **April 4, 2016** &mdash; Sensu Core version 0.23.0 has been released and is
 available for immediate download. Please note the following improvements:
 
-- **NEW:** Dropped support for Rubies < 2.0.0, as they have long been EOL
+- **NEW:** dropped support for Rubies < 2.0.0, as they have long been EOL
   and have proven to be a hindrance and security risk.
 
-- **NEW:** The Sensu Transport API changed. Transports are now a
-  deferrable, they must call succeed() once they have fully initialized.
-  Sensu now waits for its transport to fully initialize before taking
-  other actions.
+- **NEW:** the Sensu 0.23 packages use [Ruby 2.3][1].
 
-- **NEW:** Redis Sentinel support for HA Redis. Sensu services can now be
+- **NEW:** native support for [Redis Sentinel][2]. Sensu services can now be
   configured to query one or more instances of Redis Sentinel for a Redis
-  master. This feature eliminates the last need for HAProxy in highly
-  available Sensu configurations. To configure Sensu services to use Redis
-  Sentinel, hosts and ports of one or more Sentinel instances must be
-  provided, e.g. "sentinels": [{"host": "10.0.1.23", "port": 26479}].
+  master. This feature eliminates the last need for load balancing middleware
+  (e.g. HAProxy) in highly available Sensu configurations. To configure Sensu
+  services to use Redis Sentinel, hosts and ports of one or more Sentinel
+  instances must be provided.
+
+  Example Redis Sentinel configuration:
+
+  ~~~ json
+  "sentinels": [
+    {
+      "host": "10.0.1.23",
+      "port": 26479
+    }
+  ]
+  ~~~
 
 - **NEW:** Added a CLI option/argument to cause the Sensu service to print
   (output to STDOUT) its compiled configuration settings and exit. The CLI
-  option is --print_config or -P.
+  option is `--print_config` or `-P`.
 
 - **NEW:** Added token substitution to filter eval attributes, providing
-  access to event data, e.g. "occurrences": "eval: value == :::check.occurrences:::".
+  access to event data.
+
+  Example filter eval token:
+
+  ~~~ json
+  {
+    "filters": {
+      "example_filter": {
+        "attributes": {
+          "occurrences": "eval: value > :::check.occurrences:::"          
+        }
+      }
+    }
+  }
+  ~~~
+
+- **NEW:** native installer packages are now available for IBM AIX systems
+  (sensu-client only).
 
 - **NEW:** The pure Ruby EventMachine reactor is used when running on AIX.
 
-- **NEW:** The Sensu 0.23 packages use Ruby 2.3.
+- **IMPROVEMENT:** The Sensu Transport API has changed. Transports are now a deferrable,
+  they must call `succeed()` once they have fully initialized. Sensu now waits
+  for its transport to fully initialize before taking other actions.
 
-- **NEW:** Performance improvements. Dropped MultiJson in favour of Sensu
+- **IMPROVEMENT:** performance improvements. Dropped MultiJson in favour of Sensu
   JSON, a lighter weight JSON parser abstraction that supports platform
   specific parsers for Sensu Core and Enterprise. The Oj JSON parser is
-  once again used for Sensu Core. Used
-  https://github.com/JuanitoFatas/fast-ruby and benchmarks as a guide to
-  further changes.
+  once again used for Sensu Core. Used [fast-ruby][3] and benchmarks as a guide
+  to further changes.
 
-- **NEW:** Using EventMachine 1.2.0, which brings several changes and
-  improvements:
-  https://github.com/eventmachine/eventmachine/blob/master/CHANGELOG.md#1201-march-15-2016
+- **IMPROVEMENT:** Using EventMachine 1.2.0, which brings several changes and
+  improvements ([changelog][4]).
+
+[1]:  https://www.ruby-lang.org/en/news/2015/12/25/ruby-2-3-0-released/
+[2]:  http://redis.io/topics/sentinel
+[3]:  https://github.com/JuanitoFatas/fast-ruby
+[4]:  https://github.com/eventmachine/eventmachine/blob/master/CHANGELOG.md#1201-march-15-2016

--- a/source/docs/0.23/checks.md
+++ b/source/docs/0.23/checks.md
@@ -30,7 +30,7 @@ next:
   - [Check command token specification](#check-command-token-specification)
     - [Command token declaration syntax](#command-token-declaration)
     - [Command token client attributes](#command-token-client-attributes)
-    - [Command token alternate values](#command-token-alternate-values)
+    - [Command token default values](#command-token-default-values)
 - [Check configuration](#check-configuration)
   - [Example check definition](#example-check-definition)
   - [Check definition specification](#check-definition-specification)
@@ -275,22 +275,22 @@ definition attributes][16].
 - `:::disk.warning:::` would be replaced with a [custom attribute][24] called
   `warning` nested inside of a JSON hash called `disk`
 
-#### Command token alternate values
+#### Command token default values
 
-Command token alternate values can be used as a fallback in the event that no a
+Command token default values can be used as a fallback in the event that no a
 [command token client attribute][25] is not provided by the [client
-definition][16]. Command token alternate values are separated by a pipe
-character (`|`), and can be used to provide a "default values" for clients that
+definition][16]. Command token default values are separated by a pipe
+character (`|`), and can be used to provide a "fallback value" for clients that
 are missing the declared token attribute.
 
-##### Examples {#command-token-alternate-values}
+##### Examples {#command-token-default-values}
 
 - `:::url|https://sensuapp.org:::` would be replaced with a [custom
   attribute][24] called `url`. If no such attribute called `url` is included in
-  the client definition, the alternate (or default) value of
+  the client definition, the default (or fallback) value of
   `https://sensuapp.org` will be used.
 
-_NOTE: if a command token alternate value is not provided (i.e. as a default
+_NOTE: if a command token default value is not provided (i.e. as a fallback
 value), and the Sensu client definition does not have a matching [command token
 client attribute][25], a [check result][4] indicating unmatched tokens will be
 published for the check execution (e.g.: `"Unmatched command tokens:

--- a/source/docs/0.23/checks.md
+++ b/source/docs/0.23/checks.md
@@ -277,7 +277,7 @@ definition attributes][16].
 
 #### Command token default values
 
-Command token default values can be used as a fallback in the event that no a
+Command token default values can be used as a fallback in the event that a
 [command token client attribute][25] is not provided by the [client
 definition][16]. Command token default values are separated by a pipe
 character (`|`), and can be used to provide a "fallback value" for clients that

--- a/source/docs/0.23/clients.md
+++ b/source/docs/0.23/clients.md
@@ -58,12 +58,12 @@ transport (to be processed by a Sensu server).
 Sensu Client `keepalives` are the heartbeat mechanism used by Sensu to ensure
 that all registered Sensu clients are still operational and able to reach the
 [Sensu Transport][6]. Sensu clients publish keepalive messages containing client
-configuration data to the Sensu transport every 20 seconds (by default). If a
-Sensu client fails to send keepalive messages over a period of 120 seconds (by
-default), the Sensu server (or Sensu Enterprise) will create a keepalive
-[event][7]. Keepalives can be used to identify unhealthy systems and network
-partitions (among other things), and keepalive events can trigger email
-notifications and other useful actions.
+configuration data to the Sensu transport every 20 seconds. If a Sensu client
+fails to send keepalive messages over a period of 120 seconds (by default), the
+Sensu server (or Sensu Enterprise) will create a keepalive [event][7].
+Keepalives can be used to identify unhealthy systems and network partitions
+(among other things), and keepalive events can trigger email notifications and
+other useful actions.
 
 ### Client registration & the client registry {#registration-and-registry}
 
@@ -530,6 +530,14 @@ warning
 : description
   : The warning threshold (in seconds) where a Sensu client is determined to be
     unhealthy, not having sent a keepalive in so many seconds.
+
+    _WARNING: keepalive messages are sent at an interval of 20 seconds. Setting
+    a `warning` threshold of 20 seconds or fewer will result in false-positive
+    events. Also note that due to the potential for NTP synchronization issues
+    and/or network latency or packet loss interfering with regular delivery of
+    client keepalive messages, we recommend a minimum `warning` threshold of 40
+    seconds._
+
 : required
   : false
 : type
@@ -545,6 +553,14 @@ critical
 : description
   : The critical threshold (in seconds) where a Sensu client is determined to be
     unhealthy, not having sent a keepalive in so many seconds.
+
+    _WARNING: keepalive messages are sent at an interval of 20 seconds. Setting
+    a `critical` threshold of 20 seconds or fewer will result in false-positive
+    events. Also note that due to the potential for NTP synchronization issues
+    and/or network latency or packet loss interfering with regular delivery of
+    client keepalive messages, we recommend a minimum `critical` threshold of 60
+    seconds._
+
 : required
   : false
 : type

--- a/source/docs/0.23/install-redis-on-rhel-centos.md
+++ b/source/docs/0.23/install-redis-on-rhel-centos.md
@@ -74,11 +74,19 @@ configuration][5] for more information on how Sensu loads configuration.
    ~~~ json
    {
      "redis": {
-       "host": "localhost",
+       "host": "127.0.0.1",
        "port": 6379
      }
    }
    ~~~
+
+   _WARNING: using `"localhost"` instead of `127.0.0.1` for the `host`
+   configuration on systems that support IPv6 may result in an [IPv6 "localhost"
+   resolution (i.e. `::1`)][8] rather than an IPv4 "localhost" resolution (i.e.
+   `127.0.0.1`). This is not incorrect behavior because Sensu does support IPv6,
+   however if Redis is not configured to listen on IPv6, this will result in a
+   connection error and log entries indicating a **"redis connection error"**
+   with an **"unable to connect to redis server"** error message._
 
 ### Example Distributed Configuration
 
@@ -129,3 +137,4 @@ configuration][5] for more information on how Sensu loads configuration.
 [5]:  configuration
 [6]:  transport
 [7]:  installation-prerequisites#selecting-a-transport
+[8]:  https://en.wikipedia.org/wiki/IPv6_address#Local_addresses

--- a/source/docs/0.23/install-redis-on-ubuntu-debian.md
+++ b/source/docs/0.23/install-redis-on-ubuntu-debian.md
@@ -58,11 +58,19 @@ configuration][2] for more information on how Sensu loads configuration.
    ~~~ json
    {
      "redis": {
-       "host": "localhost",
+       "host": "127.0.0.1",
        "port": 6379
      }
    }
    ~~~
+
+   _WARNING: using `"localhost"` instead of `127.0.0.1` for the `host`
+   configuration on systems that support IPv6 may result in an [IPv6 "localhost"
+   resolution (i.e. `::1`)][5] rather than an IPv4 "localhost" resolution (i.e.
+   `127.0.0.1`). This is not incorrect behavior because Sensu does support IPv6,
+   however if Redis is not configured to listen on IPv6, this will result in a
+   connection error and log entries indicating a **"redis connection error"**
+   with an **"unable to connect to redis server"** error message._
 
 ### Example Distributed Configuration
 
@@ -110,3 +118,4 @@ configuration][2] for more information on how Sensu loads configuration.
 [2]:  configuration
 [3]:  transport
 [4]:  installation-prerequisites#selecting-a-transport
+[5]:  https://en.wikipedia.org/wiki/IPv6_address#Local_addresses

--- a/source/docs/0.23/sensu-on-freebsd.md
+++ b/source/docs/0.23/sensu-on-freebsd.md
@@ -9,6 +9,7 @@ title: "Sensu on FreeBSD"
 - [Installing Sensu Core](#sensu-core)
   - [Download and install Sensu using the Sensu .txz file](#download-and-install-sensu-core)
 - [Configure Sensu](#configure-sensu)
+  - [Create the Sensu configuration directory](#create-the-sensu-configuration-directory)
   - [Example client configuration](#example-client-configuration)
   - [Example transport configuration](#example-transport-configuration)
 - [Operating Sensu](#operating-sensu)
@@ -54,6 +55,16 @@ documentation._
 The following Sensu configuration files are provided as examples. Please review
 the [Sensu configuration reference documentation][5] for additional information
 on how Sensu is configured.
+
+### Create the Sensu configuration directory
+
+In some cases, the default Sensu configuration directory (i.e.
+`/etc/sensu/conf.d/`) is not created by the Sensu installer, in which case it is
+necessary to create this directory manually.
+
+~~~ shell
+mkdir /etc/sensu/conf.d
+~~~
 
 ### Example client configuration
 

--- a/source/docs/0.23/sensu-on-ibm-aix.md
+++ b/source/docs/0.23/sensu-on-ibm-aix.md
@@ -6,8 +6,143 @@ title: "Sensu on IBM AIX"
 
 # Sensu on IBM AIX
 
-Coming soon! Please subscribe to the [Sensu newsletter][1] to get notified when
-AIX packages are released, or [contact us][2] for more information.
+- [Installing Sensu Core](#sensu-core)
+  - [Download and install Sensu using the Sensu .bff file](#download-and-install-sensu-core)
+- [Configure Sensu](#configure-sensu)
+  - [Example client configuration](#example-client-configuration)
+  - [Example transport configuration](#example-transport-configuration)
+- [Operating Sensu](#operating-sensu)
+  - [Managing the Sensu client process](#service-management)
+- [Known limitations](#known-limitations)
+  - [SSL](#ssl)
+  - [Foreign Function Interface](#foreign-function-interface)
 
-[1]:  https://sensuapp.org/#newsletter
-[2]:  https://sensuapp.org/contact
+## Install Sensu Core {#sensu-core}
+
+Sensu Core is installed on IBM AIX systems via a native system installer package
+(i.e. a .bff file), which is available for download from the [Sensu
+Downloads][1] page, and from [this repository][2].
+
+### Download and install Sensu using the Sensu .bff package {#download-and-install-sensu-core}
+
+1. Download Sensu from the [Sensu Downloads][1] page, or by using this link:
+
+   ~~~ shell
+   wget http://repositories.sensuapp.org/aix/sensu-0.23.0-1.powerpc.bff
+   ~~~
+
+2. The Sensu installer package for IBM AIX systems is provided in **backup file
+   format** (.bff). In order to install the content, you will need to know the
+   "Fileset Name". Display the content using the `installp` utility.
+
+   ~~~ shell
+   installp -ld sensu-0.23.0-1.powerpc.bff
+   ~~~
+
+   Once you have collected the fileset name, you can optionally proceed to
+   preview installation using the `installp` utility, with the `-p` (preview)
+   flag.
+
+   ~~~ shell
+   installp -apXY -d sensu-0.23.0-1.powerpc.bff sensu
+   ~~~
+
+3. Install Sensu using the `installp` utility.
+
+   ~~~ shell
+   installp -aXY -d sensu-0.23.0-1.powerpc.bff sensu
+   ~~~
+
+   _NOTE: this command uses the following `installp` utilty flags: `-a` to apply
+   changes to the system, `-X` to extend the file system, and `-Y` to accept the
+   [Sensu MIT License][4]._
+
+## Configure Sensu
+
+By default, all of the Sensu services on IBM AIX systems will load configuration
+from the following locations:
+
+- `/etc/sensu/config.json`
+- `/etc/sensu/conf.d/**/*.json`
+
+_NOTE: additional or alternative configuration file and directory locations may
+be used by modifying Sensu's service configuration and/or by starting the Sensu
+services with the corresponding CLI arguments. For more information, please
+consult the [Sensu Configuration][5] reference documentation._
+
+The following Sensu configuration files are provided as examples. Please review
+the [Sensu configuration reference documentation][5] for additional information
+on how Sensu is configured.
+
+### Example client configuration
+
+1. Copy the following contents to a configuration file located at
+   `/etc/sensu/conf.d/client.json`:
+
+   ~~~ json
+   {
+     "client": {
+       "name": "aix",
+       "address": "localhost",
+       "environment": "development",
+       "subscriptions": [
+         "dev",
+         "aix"
+       ],
+       "socket": {
+         "bind": "127.0.0.1",
+         "port": 3030
+       }
+     }
+   }
+   ~~~
+
+### Example Transport Configuration
+
+At minimum, the Sensu client process requires configuration to tell it how to
+connect to the configured [Sensu Transport][6]. Please refer to the
+configuration instructions for the corresponding transport for configuration
+file examples (see [Install Redis][7], or [Install RabbitMQ][8]).
+
+## Operating Sensu
+
+### Managing the Sensu client process {#service-management}
+
+Start or stop the Sensu client using the [`startsrc` and `stopsrc`
+utilities][10]:
+
+~~~ shell
+startsrc -s sensu-client
+stopsrc -s sensu-client
+~~~
+
+## Known limitations
+
+Please note the following platform-specific limitations affecting Sensu on AIX
+at this time. Unless otherwise stated, all documented functions of the Sensu
+client are supported.
+
+### SSL
+
+Sensu on AIX does not currently support SSL as it's currently using the pure
+Ruby version of EventMachine. The C++ bindings for EventMachine do not successfully
+compile on AIX due to a bug in the xlC compiler. It is possible that SSL support
+may be possible in a future release.
+
+### Foreign Function Interface
+
+[Foreign Function Interface (FFI)][9] calls on Sensu's embedded Ruby on AIX are
+not working at this time, so any Ruby-based Sensu plugins that require FFI will
+not work (however all other plugins should work). It is possible that FFI  
+support will be enabled in a future release.
+
+[1]:  https://sensuapp.org/downloads
+[2]:  http://repositories.sensuapp.org/aix/
+[3]:  http://repositories.sensuapp.org/aix/sensu-0.23.0-1.powerpc.bff
+[4]:  https://sensuapp.org/mit-license
+[5]:  configuration
+[6]:  transport
+[7]:  install-redis
+[8]:  install-rabbitmq
+[9]:  https://github.com/ffi/ffi
+[10]: #

--- a/source/docs/0.23/sensu-on-ibm-aix.md
+++ b/source/docs/0.23/sensu-on-ibm-aix.md
@@ -9,6 +9,7 @@ title: "Sensu on IBM AIX"
 - [Installing Sensu Core](#sensu-core)
   - [Download and install Sensu using the Sensu .bff file](#download-and-install-sensu-core)
 - [Configure Sensu](#configure-sensu)
+  - [Create the Sensu configuration directory](#create-the-sensu-configuration-directory)
   - [Example client configuration](#example-client-configuration)
   - [Example transport configuration](#example-transport-configuration)
 - [Operating Sensu](#operating-sensu)
@@ -73,6 +74,16 @@ consult the [Sensu Configuration][5] reference documentation._
 The following Sensu configuration files are provided as examples. Please review
 the [Sensu configuration reference documentation][5] for additional information
 on how Sensu is configured.
+
+### Create the Sensu configuration directory
+
+In some cases, the default Sensu configuration directory (i.e.
+`/etc/sensu/conf.d/`) is not created by the Sensu installer, in which case it is
+necessary to create this directory manually.
+
+~~~ shell
+mkdir /etc/sensu/conf.d
+~~~
 
 ### Example client configuration
 

--- a/source/docs/0.23/sensu-on-mac-os-x.md
+++ b/source/docs/0.23/sensu-on-mac-os-x.md
@@ -9,6 +9,7 @@ title: "Sensu on Mac OS X"
 - [Installing Sensu Core](#sensu-core)
   - [Download and install Sensu using the Sensu Universal .pkg file](#download-and-install-sensu-core)
 - [Configure Sensu](#configure-sensu)
+  - [Create the Sensu configuration directory](#create-the-sensu-configuration-directory)
   - [Example client configuration](#example-client-configuration)
   - [Example transport configuration](#example-transport-configuration)
   - [Configure the Sensu client `launchd` daemon](#configure-the-sensu-client-launchd-daemon)
@@ -59,6 +60,16 @@ section, below._
 The following Sensu configuration files are provided as examples. Please review
 the [Sensu configuration reference documentation][5] for additional information
 on how Sensu is configured.
+
+### Create the Sensu configuration directory
+
+In some cases, the default Sensu configuration directory (i.e.
+`/etc/sensu/conf.d/`) is not created by the Sensu installer, in which case it is
+necessary to create this directory manually.
+
+~~~ shell
+mkdir /etc/sensu/conf.d
+~~~
 
 ### Example client configuration
 

--- a/source/docs/0.23/sensu-on-mac-os-x.md
+++ b/source/docs/0.23/sensu-on-mac-os-x.md
@@ -111,11 +111,11 @@ configuration file) to configure the `sensu-client` daemon run arguments (e.g.
 
 1. To configure the Sensu client service wrapper, copy the default service
    definition file entitled `org.sensuapp.sensu-client.plist` to
-   `/etc/sensu/org.sensuapp.sensu-client.plist` and edit it with your favorite
-   text editor.
+   `/Library/LaunchDaemons/org.sensuapp.sensu-client.plist` and edit it with
+   your favorite text editor.
 
    ~~~ shell
-   sudo cp /opt/sensu/embedded/Cellar/sensu/0.23.0/Library/LaunchDaemons/org.sensuapp.sensu-client.plist /etc/sensu/org.sensuapp.sensu-client.plist
+   sudo cp /opt/sensu/embedded/Cellar/sensu/0.23.0/Library/LaunchDaemons/org.sensuapp.sensu-client.plist /Library/LaunchDaemons/org.sensuapp.sensu-client.plist
    ~~~
 
 2. This XML configuration file allows you to set Sensu client [CLI
@@ -154,8 +154,8 @@ configuration file) to configure the `sensu-client` daemon run arguments (e.g.
 Start or stop the Sensu client using the [`launchctl` utility][11]:
 
 ~~~ shell
-sudo launchctl load -w /etc/sensu/org.sensuapp.sensu-client.plist
-sudo launchctl unload -w /etc/sensu/org.sensuapp.sensu-client.plist
+sudo launchctl load -w /Library/LaunchDaemons/org.sensuapp.sensu-client.plist
+sudo launchctl unload -w /Library/LaunchDaemons/org.sensuapp.sensu-client.plist
 ~~~
 
 

--- a/source/docs/0.23/sensu-on-rhel-centos.md
+++ b/source/docs/0.23/sensu-on-rhel-centos.md
@@ -12,6 +12,7 @@ title: "Install Sensu on RHEL/CentOS"
   - [Install the Sensu Enterprise repository](#install-sensu-enterprise-repository)
   - [Install Sensu Enterprise (server & API)](#install-sensu-enterprise)
 - [Configure Sensu](#configure-sensu)
+  - [Create the Sensu configuration directory](#create-the-sensu-configuration-directory)
   - [Example client configuration](#example-client-configuration)
   - [Example transport configuration](#example-transport-configuration)
   - [Example data store configuration](#example-data-store-configuration)
@@ -130,6 +131,16 @@ with the corresponding CLI arguments. For more information, please consult the
 The following Sensu configuration files are provided as examples. Please review
 the [Sensu configuration reference documentation][3] for additional information
 on how Sensu is configured.
+
+### Create the Sensu configuration directory
+
+In some cases, the default Sensu configuration directory (i.e.
+`/etc/sensu/conf.d/`) is not created by the Sensu installer, in which case it is
+necessary to create this directory manually.
+
+~~~ shell
+mkdir /etc/sensu/conf.d
+~~~
 
 ### Example client configuration
 

--- a/source/docs/0.23/sensu-on-ubuntu-debian.md
+++ b/source/docs/0.23/sensu-on-ubuntu-debian.md
@@ -12,6 +12,7 @@ title: "Install Sensu on Ubuntu/Debian"
   - [Install the Sensu Enterprise repository](#install-sensu-enterprise-repository)
   - [Install Sensu Enterprise (server & API)](#install-sensu-enterprise)
 - [Configure Sensu](#configure-sensu)
+  - [Create the Sensu configuration directory](#create-the-sensu-configuration-directory)
   - [Example client configuration](#example-client-configuration)
   - [Example transport configuration](#example-transport-configuration)
   - [Example data store configuration](#example-data-store-configuration)
@@ -133,6 +134,16 @@ with the corresponding CLI arguments. For more information, please consult the
 The following Sensu configuration files are provided as examples. Please review
 the [Sensu configuration reference documentation][3] for additional information
 on how Sensu is configured.
+
+### Create the Sensu configuration directory
+
+In some cases, the default Sensu configuration directory (i.e.
+`/etc/sensu/conf.d/`) is not created by the Sensu installer, in which case it is
+necessary to create this directory manually.
+
+~~~ shell
+sudo mkdir /etc/sensu/conf.d
+~~~
 
 ### Example client configuration
 

--- a/source/docs/index.md
+++ b/source/docs/index.md
@@ -4,32 +4,38 @@ title: Sensu versions
 hide_toc: true
 ---
 
-### [Version 0.23](/docs/0.23/overview) ([changelog](/docs/0.23/changelog)) (Latest)
+### [Latest version](/docs/latest/overview) ([changelog](/docs/latest/changelog))
 
-### [Version 0.22](/docs/0.22/overview) ([changelog](/docs/0.22/changelog))
+--------------------------------------------------------------------------------
 
-### [Version 0.21](/docs/0.21/overview)
+### All Versions
 
-### [Version 0.20](/docs/0.20/overview)
+#### [Version 0.23](/docs/0.23/overview) ([changelog](/docs/0.23/changelog)) (Latest)
 
-### [Version 0.19](/docs/0.19/overview)
+#### [Version 0.22](/docs/0.22/overview) ([changelog](/docs/0.22/changelog))
 
-### [Version 0.18](/docs/0.18/overview)
+#### [Version 0.21](/docs/0.21/overview)
 
-### [Version 0.17](/docs/0.17/overview)
+#### [Version 0.20](/docs/0.20/overview)
 
-### [Version 0.16](/docs/legacy)
+#### [Version 0.19](/docs/0.19/overview)
 
-### [Version 0.15](/docs/legacy)
+#### [Version 0.18](/docs/0.18/overview)
 
-### [Version 0.14](/docs/legacy)
+#### [Version 0.17](/docs/0.17/overview)
 
-### [Version 0.13](/docs/legacy)
+#### [Version 0.16](/docs/legacy)
 
-### [Version 0.12](/docs/legacy)
+#### [Version 0.15](/docs/legacy)
 
-### [Version 0.11](/docs/legacy)
+#### [Version 0.14](/docs/legacy)
 
-### [Version 0.10](/docs/legacy)
+#### [Version 0.13](/docs/legacy)
 
-### [Version 0.9](/docs/legacy)
+#### [Version 0.12](/docs/legacy)
+
+#### [Version 0.11](/docs/legacy)
+
+#### [Version 0.10](/docs/legacy)
+
+#### [Version 0.9](/docs/legacy)

--- a/source/docs/index.md
+++ b/source/docs/index.md
@@ -4,9 +4,9 @@ title: Sensu versions
 hide_toc: true
 ---
 
-### [Version 0.23 (Latest)](/docs/0.23/overview) ([changelog](/docs/0.23/changelog))
+### [Version 0.23](/docs/0.23/overview) ([changelog](/docs/0.23/changelog)) (Latest)
 
-### [Version 0.22](/docs/0.22/overview)
+### [Version 0.22](/docs/0.22/overview) ([changelog](/docs/0.22/changelog))
 
 ### [Version 0.21](/docs/0.21/overview)
 


### PR DESCRIPTION
Sensu 0.23 was shipped this week, along with an initial copy of 0.22 => 0.23 documentation, which only included new content for one of 0.23's [new features](https://sensuapp.org/docs/latest/changelog) ([native Redis Sentinel support](https://sensuapp.org/docs/latest/redis#configuring-sensu-for-ha-redis)). 

I'm opening this WIP PR to track work on documentation for all of the new 0.23 features, along with improvements addressing [open issues and PRs tagged for the `0.23-docs` milestone](https://github.com/sensu/sensu-docs/milestones/0.23-docs). 
