### PR TITLE
Simplifies IPv6 issue wording.

### DIFF
--- a/docs/0.23/reference/redis.md
+++ b/docs/0.23/reference/redis.md
@@ -144,8 +144,8 @@ The Redis definition uses the `"redis": {}` definition scope.
     _WARNING: using `"localhost"` instead of `127.0.0.1` for the host
     configuration on systems that support IPv6 may result in an IPv6 "localhost"
     resolution (i.e. `::1`) rather than an IPv4 "localhost" resolution (i.e.
-    `127.0.0.1`). This is not incorrect behavior because **Sensu does support
-    IPv6**, however if Redis is not configured to listen on IPv6, this will
+    `127.0.0.1`). Sensu does support
+    IPv6, so this may be desirable; however, if Redis is not configured to listen on IPv6, this will
     result in a connection error and log entries indicating a `"redis connection
     error"` with an `"unable to connect to redis server"` error message._
 

--- a/docs/0.24/reference/redis.md
+++ b/docs/0.24/reference/redis.md
@@ -145,8 +145,8 @@ The Redis definition uses the `"redis": {}` definition scope.
     _WARNING: using `"localhost"` instead of `127.0.0.1` for the host
     configuration on systems that support IPv6 may result in an IPv6 "localhost"
     resolution (i.e. `::1`) rather than an IPv4 "localhost" resolution (i.e.
-    `127.0.0.1`). This is not incorrect behavior because **Sensu does support
-    IPv6**, however if Redis is not configured to listen on IPv6, this will
+    `127.0.0.1`). Sensu does support
+    IPv6, so this may be desirable; however, if Redis is not configured to listen on IPv6, this will
     result in a connection error and log entries indicating a `"redis connection
     error"` with an `"unable to connect to redis server"` error message._
 

--- a/docs/0.25/reference/redis.md
+++ b/docs/0.25/reference/redis.md
@@ -145,8 +145,8 @@ The Redis definition uses the `"redis": {}` definition scope.
     _WARNING: using `"localhost"` instead of `127.0.0.1` for the host
     configuration on systems that support IPv6 may result in an IPv6 "localhost"
     resolution (i.e. `::1`) rather than an IPv4 "localhost" resolution (i.e.
-    `127.0.0.1`). This is not incorrect behavior because **Sensu does support
-    IPv6**, however if Redis is not configured to listen on IPv6, this will
+    `127.0.0.1`). Sensu does support
+    IPv6, so this may be desirable; however, if Redis is not configured to listen on IPv6, this will
     result in a connection error and log entries indicating a `"redis connection
     error"` with an `"unable to connect to redis server"` error message._
 

--- a/docs/0.26/reference/redis.md
+++ b/docs/0.26/reference/redis.md
@@ -145,8 +145,8 @@ The Redis definition uses the `"redis": {}` definition scope.
     _WARNING: using `"localhost"` instead of `127.0.0.1` for the host
     configuration on systems that support IPv6 may result in an IPv6 "localhost"
     resolution (i.e. `::1`) rather than an IPv4 "localhost" resolution (i.e.
-    `127.0.0.1`). This is not incorrect behavior because **Sensu does support
-    IPv6**, however if Redis is not configured to listen on IPv6, this will
+    `127.0.0.1`). Sensu does support
+    IPv6, so this may be desirable; however, if Redis is not configured to listen on IPv6, this will
     result in a connection error and log entries indicating a `"redis connection
     error"` with an `"unable to connect to redis server"` error message._
 


### PR DESCRIPTION
Looks like changes made it into latest. Updating older versions for clarity.
Replaces https://github.com/sensu/sensu-docs/pull/392
