### PR TITLE
Fix formatting and typos in aggregates and silenced API docs

### DIFF
--- a/docs/0.26/api/aggregates-api.md
+++ b/docs/0.26/api/aggregates-api.md
@@ -17,10 +17,10 @@ next:
 - [The `/aggregates/:name` API endpoints](#the-aggregatesname-api-endpoints)
   - [`/aggregates/:name` (GET)](#aggregatesname-get)
   - [`/aggregates/:name` (DELETE)](#aggregatesname-delete)
-- [The `/aggregates/:name/:clients` API endpoint](#the-aggregatesnameclients-api-endpoint)
-  - [`/aggregates/:name/:clients` (GET)](#aggregatesnameclients-get)
-- [The `/aggregates/:name/:checks` API endpoint](#the-aggregatesnamechecks-api-endpoint)
-  - [`/aggregates/:name/:checks` (GET)](#aggregatesnamechecks-get)
+- [The `/aggregates/:name/clients` API endpoint](#the-aggregatesnameclients-api-endpoint)
+  - [`/aggregates/:name/clients` (GET)](#aggregatesnameclients-get)
+- [The `/aggregates/:name/checks` API endpoint](#the-aggregatesnamechecks-api-endpoint)
+  - [`/aggregates/:name/checks` (GET)](#aggregatesnamechecks-get)
 - [The `/aggregates/:name/results/:severity` API endpoint](#the-aggregatesnameresultsseverity-api-endpoint)
   - [`/aggregates/:name/results/:severity` (GET)](#aggregatesnameresultsseverity-get)
 
@@ -48,7 +48,7 @@ $ curl -s http://localhost:4567/aggregates | jq .
 
 #### API specification {#aggregates-get-specification}
 
-`/aggregates` (GET)  
+`/aggregates` (GET)
 : desc
   : Returns the list of named aggregates.
 : example url
@@ -177,16 +177,16 @@ Server: thin
     Server: thin
     ~~~
 
-## The `/aggregates/:name/:clients` API endpoint
+## The `/aggregates/:name/clients` API endpoint
 
-The `/aggregates/:name/:clients` API endpoint provides HTTP GET access to the
+The `/aggregates/:name/clients` API endpoint provides HTTP GET access to the
 Sensu client members of a [named aggregate][1].
 
-### `/aggregates/:name/:clients` (GET)
+### `/aggregates/:name/clients` (GET)
 
 #### EXAMPLES {#aggregatesnameclients-get-examples}
 
-The following example demonstrates a `/aggregates/:name/:clients` API query for
+The following example demonstrates a `/aggregates/:name/clients` API query for
 the client members of an aggregate named `elasticsearch`.
 
 ~~~ shell
@@ -206,11 +206,11 @@ $ curl -s http://localhost:4567/aggregates/elasticsearch/clients | jq .
     ]
   },
 ]
-~~~  
+~~~
 
 #### API specification {#aggregatesnameclients-get-specification}
 
-`/aggregates/:name/:clients` (GET)
+`/aggregates/:name/clients` (GET)
 : desc
   : Returns the client members of a named aggregate.
 : example URL
@@ -240,16 +240,16 @@ $ curl -s http://localhost:4567/aggregates/elasticsearch/clients | jq .
     ]
     ~~~
 
-## The `/aggregates/:name/:checks` API endpoint
+## The `/aggregates/:name/checks` API endpoint
 
-The `/aggregates/:name/:checks` API endpoint provides HTTP GET access to the
+The `/aggregates/:name/checks` API endpoint provides HTTP GET access to the
 Sensu check members of a [named aggregate][1].
 
-### `/aggregates/:name/:checks` (GET)
+### `/aggregates/:name/checks` (GET)
 
 #### EXAMPLES {#aggregatesnamechecks-get-examples}
 
-The following example demonstrates a `/aggregates/:name/:checks` API query for
+The following example demonstrates a `/aggregates/:name/checks` API query for
 the check members of an aggregate named `elasticsearch`.
 
 ~~~ shell
@@ -269,11 +269,11 @@ $ curl -s http://localhost:4567/aggregates/elasticsearch/checks | jq .
     ]
   }
 ]
-~~~  
+~~~
 
 #### API specification {#aggregatesnamechecks-get-specification}
 
-`/aggregates/:name/:checks` (GET)
+`/aggregates/:name/checks` (GET)
 : desc
   : Returns the check members of a named aggregate.
 : example URL
@@ -329,7 +329,7 @@ $ curl -s http://localhost:4567/aggregates/elasticsearch/results/critical | jq .
     ]
   }
 ]
-~~~  
+~~~
 
 #### API specification {#aggregatesnameresultsseverity-get-specification}
 

--- a/docs/0.26/api/silenced-api.md
+++ b/docs/0.26/api/silenced-api.md
@@ -170,14 +170,14 @@ $ curl -s -X GET http://localhost:4567/silenced | jq .
       - **required**: false
       - **type**: Boolean
       - **description**: If specified as true, the silence entry will be
-      automatically cleared once the condition it is siliencing is resolved.
+      automatically cleared once the condition it is silencing is resolved.
       - **example**: true
   : - `reason`
       - **required**: false
       - **type**: String
       - **description**: If specified, this free-form string is used to provide context
       or rationale for the reason this silence entry was created.
-      - **example**: "pre-arranged maintenenance window"
+      - **example**: "pre-arranged maintenance window"
   : - `subscription`: String, required if `check` not specified
       - **required**: true, unless `client` is specified
       - **type:** String
@@ -294,7 +294,7 @@ $ curl -s -X GET http://localhost:4567/silenced | jq .
     - **Malformed**: 400 (Bad Request)
     - **Error**: 500 (Internal Server Error)
 
-### `/silended/subscriptions/:subscription` (GET)
+### `/silenced/subscriptions/:subscription` (GET)
 
 #### Example: Querying for silence entries via subscription name
 
@@ -341,7 +341,7 @@ $ curl -s -X GET http://localhost:4567/silenced/subscriptions/load-balancer | jq
   : - **Success**: 200 (OK)
     - **Error**: 500 (Internal Server Error)
 
-### `/silended/checks/:check` (GET)
+### `/silenced/checks/:check` (GET)
 
 #### Example: Querying for silence entries via check name
 


### PR DESCRIPTION
- Aggregates API: Removed extraneous colons prefixing the `clients` and `checks` path segments
- Aggregates API: Removed extraneous whitespace
- Silenced API: Fixed spelling errors
