### PR TITLE
[install-rabbitmq] remove confusing comparison to redis os requirements

### DIFF
--- a/docs/0.23/installation/install-rabbitmq.md
+++ b/docs/0.23/installation/install-rabbitmq.md
@@ -16,10 +16,9 @@ messaging broker - an intermediary for messaging. It gives your applications a
 common platform to send and receive messages, and your messages a safe place to
 live until received"_. RabbitMQ is also the default [Sensu Transport][3]. When
 using RabbitMQ as the Sensu Transport, all Sensu services require access to the
-same instance (or cluster) of RabbitMQ to function. Although it is possible
-to install and run Redis on almost any modern operating system, **all Sensu
-users are encouraged to install and run RabbitMQ on one of the following
-supported platforms**
+same instance (or cluster) of RabbitMQ to function. **All Sensu users are
+encouraged to install and run RabbitMQ on one of the following supported
+platforms:**
 
 - [Install RabbitMQ on Ubuntu/Debian](install-rabbitmq-on-ubuntu-debian.html) (recommended)
 - [Install RabbitMQ on RHEL/CentOS](install-rabbitmq-on-rhel-centos.html)

--- a/docs/0.24/installation/install-rabbitmq.md
+++ b/docs/0.24/installation/install-rabbitmq.md
@@ -16,10 +16,9 @@ messaging broker - an intermediary for messaging. It gives your applications a
 common platform to send and receive messages, and your messages a safe place to
 live until received"_. RabbitMQ is also the default [Sensu Transport][3]. When
 using RabbitMQ as the Sensu Transport, all Sensu services require access to the
-same instance (or cluster) of RabbitMQ to function. Although it is possible
-to install and run Redis on almost any modern operating system, **all Sensu
-users are encouraged to install and run RabbitMQ on one of the following
-supported platforms**
+same instance (or cluster) of RabbitMQ to function. **All Sensu users are
+encouraged to install and run RabbitMQ on one of the following supported
+platforms:**
 
 - [Install RabbitMQ on Ubuntu/Debian](install-rabbitmq-on-ubuntu-debian.html) (recommended)
 - [Install RabbitMQ on RHEL/CentOS](install-rabbitmq-on-rhel-centos.html)

--- a/docs/0.25/installation/install-rabbitmq.md
+++ b/docs/0.25/installation/install-rabbitmq.md
@@ -16,10 +16,9 @@ messaging broker - an intermediary for messaging. It gives your applications a
 common platform to send and receive messages, and your messages a safe place to
 live until received"_. RabbitMQ is also the default [Sensu Transport][3]. When
 using RabbitMQ as the Sensu Transport, all Sensu services require access to the
-same instance (or cluster) of RabbitMQ to function. Although it is possible
-to install and run Redis on almost any modern operating system, **all Sensu
-users are encouraged to install and run RabbitMQ on one of the following
-supported platforms**
+same instance (or cluster) of RabbitMQ to function. **All Sensu users are
+encouraged to install and run RabbitMQ on one of the following supported
+platforms:**
 
 - [Install RabbitMQ on Ubuntu/Debian](install-rabbitmq-on-ubuntu-debian.html) (recommended)
 - [Install RabbitMQ on RHEL/CentOS](install-rabbitmq-on-rhel-centos.html)

--- a/docs/0.26/installation/install-rabbitmq.md
+++ b/docs/0.26/installation/install-rabbitmq.md
@@ -16,10 +16,8 @@ messaging broker - an intermediary for messaging. It gives your applications a
 common platform to send and receive messages, and your messages a safe place to
 live until received"_. RabbitMQ is also the default [Sensu Transport][3]. When
 using RabbitMQ as the Sensu Transport, all Sensu services require access to the
-same instance (or cluster) of RabbitMQ to function. Although it is possible
-to install and run Redis on almost any modern operating system, **all Sensu
-users are encouraged to install and run RabbitMQ on one of the following
-supported platforms**
+same instance (or cluster) of RabbitMQ to function. **All Sensu users are
+encouraged to install and run RabbitMQ on one of the following supported platforms:**
 
 - [Install RabbitMQ on Ubuntu/Debian](install-rabbitmq-on-ubuntu-debian.html) (recommended)
 - [Install RabbitMQ on RHEL/CentOS](install-rabbitmq-on-rhel-centos.html)


### PR DESCRIPTION
As reported by email:

> Hello,
> 
> https://sensuapp.org/docs/latest/installation/install-rabbitmq.html
> 
> "possible to install and run Redis on"  should be  "possible to install and run
> RabbitMQ on"

My read: [the text](https://github.com/sensu/sensu-docs/blob/10da04cd71a9d5c547a066391bc9c3790fc397a2/docs/0.23/installation/install-rabbitmq.md) as written is trying to communicate that redis runs most anywhere but a usable
rabbitmq instance has more specific requirements.

I propose that we remove the comparison. In my view, we don't encourage folks to adopt redis
transport in production, and it seems to have made at least one person confused as to why 
we're talking about it on this page about RabbitMQ.
