### PR TITLE
Windows platform fixups

### DIFF
--- a/docs/0.23/platforms/sensu-on-microsoft-windows.md
+++ b/docs/0.23/platforms/sensu-on-microsoft-windows.md
@@ -57,7 +57,7 @@ By default, all of the Sensu services on Microsoft Windows systems will load
 configuration from the following locations:
 
 - `C:\opt\sensu\config.json`
-- `C:\ops\sensu\conf.d\`
+- `C:\opt\sensu\conf.d\`
 
 _NOTE: in general, where references to configuration file locations found
 elsewhere in the Sensu documentation suggest paths beginning with `/etc/sensu`,

--- a/docs/0.23/platforms/sensu-on-microsoft-windows.md
+++ b/docs/0.23/platforms/sensu-on-microsoft-windows.md
@@ -158,18 +158,14 @@ file path to `C:\opt\sensu\config.json`, the Sensu configuration directory to
 
 ### Install the Sensu client Windows service
 
-1. Obtain the hostname or IP address of the Windows system where the Sensu
-   client is installed. For the purpose of this example, we will assume
-   `10.0.1.100` is our IP address.
+Open a Command Prompt and use the [Windows SC][10] utility to create the Windows
+service for the Sensu client:
 
-2. Open a Command Prompt and use the [Windows SC][10] utility to create the
-   Windows service for the Sensu client:
+~~~ cmd
+sc create sensu-client start= delayed-auto binPath= c:\opt\sensu\bin\sensu-client.exe DisplayName= "Sensu Client"
+~~~
 
-   ~~~ cmd
-   sc \\10.0.1.100 create sensu-client start= delayed-auto binPath= c:\opt\sensu\bin\sensu-client.exe DisplayName= "Sensu Client"
-   ~~~
-
-   _NOTE: the space between the equals (=) and the values is required._
+_NOTE: the space between the equals (=) and the values is required._
 
 ## Operating Sensu
 

--- a/docs/0.23/platforms/sensu-on-microsoft-windows.md
+++ b/docs/0.23/platforms/sensu-on-microsoft-windows.md
@@ -181,8 +181,8 @@ To manually start and stop the Sensu client Windows service, use the
 - Start or stop the Sensu client
 
   ~~~ shell
-  sc sensu-client start
-  sc sensu-client stop
+  sc start sensu-client
+  sc stop sensu-client
   ~~~
 
 

--- a/docs/0.24/platforms/sensu-on-microsoft-windows.md
+++ b/docs/0.24/platforms/sensu-on-microsoft-windows.md
@@ -57,7 +57,7 @@ By default, all of the Sensu services on Microsoft Windows systems will load
 configuration from the following locations:
 
 - `C:\opt\sensu\config.json`
-- `C:\ops\sensu\conf.d\`
+- `C:\opt\sensu\conf.d\`
 
 _NOTE: in general, where references to configuration file locations found
 elsewhere in the Sensu documentation suggest paths beginning with `/etc/sensu`,

--- a/docs/0.24/platforms/sensu-on-microsoft-windows.md
+++ b/docs/0.24/platforms/sensu-on-microsoft-windows.md
@@ -158,18 +158,14 @@ file path to `C:\opt\sensu\config.json`, the Sensu configuration directory to
 
 ### Install the Sensu client Windows service
 
-1. Obtain the hostname or IP address of the Windows system where the Sensu
-   client is installed. For the purpose of this example, we will assume
-   `10.0.1.100` is our IP address.
+Open a Command Prompt and use the [Windows SC][10] utility to create the Windows
+service for the Sensu client:
 
-2. Open a Command Prompt and use the [Windows SC][10] utility to create the
-   Windows service for the Sensu client:
+~~~ cmd
+sc create sensu-client start= delayed-auto binPath= c:\opt\sensu\bin\sensu-client.exe DisplayName= "Sensu Client"
+~~~
 
-   ~~~ cmd
-   sc \\10.0.1.100 create sensu-client start= delayed-auto binPath= c:\opt\sensu\bin\sensu-client.exe DisplayName= "Sensu Client"
-   ~~~
-
-   _NOTE: the space between the equals (=) and the values is required._
+_NOTE: the space between the equals (=) and the values is required._
 
 ## Operating Sensu
 

--- a/docs/0.24/platforms/sensu-on-microsoft-windows.md
+++ b/docs/0.24/platforms/sensu-on-microsoft-windows.md
@@ -181,8 +181,8 @@ To manually start and stop the Sensu client Windows service, use the
 - Start or stop the Sensu client
 
   ~~~ shell
-  sc sensu-client start
-  sc sensu-client stop
+  sc start sensu-client
+  sc stop sensu-client
   ~~~
 
 

--- a/docs/0.25/platforms/sensu-on-microsoft-windows.md
+++ b/docs/0.25/platforms/sensu-on-microsoft-windows.md
@@ -57,7 +57,7 @@ By default, all of the Sensu services on Microsoft Windows systems will load
 configuration from the following locations:
 
 - `C:\opt\sensu\config.json`
-- `C:\ops\sensu\conf.d\`
+- `C:\opt\sensu\conf.d\`
 
 _NOTE: in general, where references to configuration file locations found
 elsewhere in the Sensu documentation suggest paths beginning with `/etc/sensu`,

--- a/docs/0.25/platforms/sensu-on-microsoft-windows.md
+++ b/docs/0.25/platforms/sensu-on-microsoft-windows.md
@@ -158,18 +158,14 @@ file path to `C:\opt\sensu\config.json`, the Sensu configuration directory to
 
 ### Install the Sensu client Windows service
 
-1. Obtain the hostname or IP address of the Windows system where the Sensu
-   client is installed. For the purpose of this example, we will assume
-   `10.0.1.100` is our IP address.
+Open a Command Prompt and use the [Windows SC][10] utility to create the Windows
+service for the Sensu client:
 
-2. Open a Command Prompt and use the [Windows SC][10] utility to create the
-   Windows service for the Sensu client:
+~~~ cmd
+sc create sensu-client start= delayed-auto binPath= c:\opt\sensu\bin\sensu-client.exe DisplayName= "Sensu Client"
+~~~
 
-   ~~~ cmd
-   sc \\10.0.1.100 create sensu-client start= delayed-auto binPath= c:\opt\sensu\bin\sensu-client.exe DisplayName= "Sensu Client"
-   ~~~
-
-   _NOTE: the space between the equals (=) and the values is required._
+_NOTE: the space between the equals (=) and the values is required._
 
 ## Operating Sensu
 

--- a/docs/0.25/platforms/sensu-on-microsoft-windows.md
+++ b/docs/0.25/platforms/sensu-on-microsoft-windows.md
@@ -181,8 +181,8 @@ To manually start and stop the Sensu client Windows service, use the
 - Start or stop the Sensu client
 
   ~~~ shell
-  sc sensu-client start
-  sc sensu-client stop
+  sc start sensu-client
+  sc stop sensu-client
   ~~~
 
 

--- a/docs/0.26/platforms/sensu-on-microsoft-windows.md
+++ b/docs/0.26/platforms/sensu-on-microsoft-windows.md
@@ -57,7 +57,7 @@ By default, all of the Sensu services on Microsoft Windows systems will load
 configuration from the following locations:
 
 - `C:\opt\sensu\config.json`
-- `C:\ops\sensu\conf.d\`
+- `C:\opt\sensu\conf.d\`
 
 _NOTE: in general, where references to configuration file locations found
 elsewhere in the Sensu documentation suggest paths beginning with `/etc/sensu`,

--- a/docs/0.26/platforms/sensu-on-microsoft-windows.md
+++ b/docs/0.26/platforms/sensu-on-microsoft-windows.md
@@ -158,18 +158,14 @@ file path to `C:\opt\sensu\config.json`, the Sensu configuration directory to
 
 ### Install the Sensu client Windows service
 
-1. Obtain the hostname or IP address of the Windows system where the Sensu
-   client is installed. For the purpose of this example, we will assume
-   `10.0.1.100` is our IP address.
+Open a Command Prompt and use the [Windows SC][10] utility to create the Windows
+service for the Sensu client:
 
-2. Open a Command Prompt and use the [Windows SC][10] utility to create the
-   Windows service for the Sensu client:
+~~~ cmd
+sc create sensu-client start= delayed-auto binPath= c:\opt\sensu\bin\sensu-client.exe DisplayName= "Sensu Client"
+~~~
 
-   ~~~ cmd
-   sc \\10.0.1.100 create sensu-client start= delayed-auto binPath= c:\opt\sensu\bin\sensu-client.exe DisplayName= "Sensu Client"
-   ~~~
-
-   _NOTE: the space between the equals (=) and the values is required._
+_NOTE: the space between the equals (=) and the values is required._
 
 ## Operating Sensu
 

--- a/docs/0.26/platforms/sensu-on-microsoft-windows.md
+++ b/docs/0.26/platforms/sensu-on-microsoft-windows.md
@@ -181,8 +181,8 @@ To manually start and stop the Sensu client Windows service, use the
 - Start or stop the Sensu client
 
   ~~~ shell
-  sc sensu-client start
-  sc sensu-client stop
+  sc start sensu-client
+  sc stop sensu-client
   ~~~
 
 


### PR DESCRIPTION
While testing omnibus builds on Windows with @amdprophet, we found some discrepancies in the Windows platform page:
- Fix invalid path across all versions (originally raised in #443)
- Fix order of arguments for `sc` command
- Attempt to simplify instructions by removing use of local machine's non-loopback IP

As far as I can tell, specifying the IP address is not required when modifying
the local system. Seeing as we provide a link to the [TechNet reference](https://technet.microsoft.com/en-us/library/bb490995.aspx), I think
we can simplify instructions by removing this bit about IP addresses.

Closes #443 
