### PR TITLE
Clarify that not all transports support every known type of pipe

### DIFF
--- a/docs/0.23/reference/handlers.md
+++ b/docs/0.23/reference/handlers.md
@@ -490,6 +490,10 @@ handlers configured with `"type": "transport"`)._
     "type": "direct"
     ~~~
 
+_NOTE: types `direct`, `fanout` and `topic` are supported by the default
+RabbitMQ transport. Redis and other transports may only implement a subset of
+these._
+
 `name`
 : description
   : The Sensu transport pipe name.

--- a/docs/0.24/reference/handlers.md
+++ b/docs/0.24/reference/handlers.md
@@ -491,6 +491,10 @@ handlers configured with `"type": "transport"`)._
     "type": "direct"
     ~~~
 
+_NOTE: types `direct`, `fanout` and `topic` are supported by the default
+RabbitMQ transport. Redis and other transports may only implement a subset of
+these._
+
 `name`
 : description
   : The Sensu transport pipe name.

--- a/docs/0.25/reference/handlers.md
+++ b/docs/0.25/reference/handlers.md
@@ -491,6 +491,10 @@ handlers configured with `"type": "transport"`)._
     "type": "direct"
     ~~~
 
+_NOTE: types `direct`, `fanout` and `topic` are supported by the default
+RabbitMQ transport. Redis and other transports may only implement a subset of
+these._
+
 `name`
 : description
   : The Sensu transport pipe name.

--- a/docs/0.26/reference/handlers.md
+++ b/docs/0.26/reference/handlers.md
@@ -505,6 +505,10 @@ handlers configured with `"type": "transport"`)._
     "type": "direct"
     ~~~
 
+_NOTE: types `direct`, `fanout` and `topic` are supported by the default
+RabbitMQ transport. Redis and other transports may only implement a subset of
+these._
+
 `name`
 : description
   : The Sensu transport pipe name.


### PR DESCRIPTION
In #447 it is suggested to remove transport pipe types which are not supported by the redis transport. As RabbitMQ is the prefered transport, I don't think this is reasonable. Instead I've added a note indicating that Redis and other transports may only implement a subset of the known transport pipe types.

Closes #447 
