### PR TITLE
Remove duplicate word "about" in checks reference doc

### DIFF
--- a/docs/0.23/reference/checks.md
+++ b/docs/0.23/reference/checks.md
@@ -181,7 +181,7 @@ client name the result was submitted from, and the `output` of the check.
 ~~~
 
 _NOTE: please refer to the [check result specification][38] (below) for more
-information about about check results._
+information about check results._
 
 ## Check command tokens
 

--- a/docs/0.24/reference/checks.md
+++ b/docs/0.24/reference/checks.md
@@ -182,7 +182,7 @@ client name the result was submitted from, and the `output` of the check.
 ~~~
 
 _NOTE: please refer to the [check result specification][38] (below) for more
-information about about check results._
+information about check results._
 
 ## Check token substitution
 

--- a/docs/0.25/reference/checks.md
+++ b/docs/0.25/reference/checks.md
@@ -182,7 +182,7 @@ client name the result was submitted from, and the `output` of the check.
 ~~~
 
 _NOTE: please refer to the [check result specification][38] (below) for more
-information about about check results._
+information about check results._
 
 ## Check token substitution
 

--- a/docs/0.26/reference/checks.md
+++ b/docs/0.26/reference/checks.md
@@ -182,7 +182,7 @@ client name the result was submitted from, and the `output` of the check.
 ~~~
 
 _NOTE: please refer to the [check result specification][38] (below) for more
-information about about check results._
+information about check results._
 
 ## Check token substitution
 


### PR DESCRIPTION
Fixes duplicated word in all versions of checks reference document, as
originally reported in #446.

Closes #446.
