### PR TITLE
Second process needs to be mentioned.

### DIFF
--- a/docs/0.26/installation/install-sensu-server-api.md
+++ b/docs/0.26/installation/install-sensu-server-api.md
@@ -48,7 +48,7 @@ Linux-based operating systems, only (i.e. .deb and .rpm). The Sensu Enterprise
 installer packages are made available via the Sensu Enterprise software
 repositories, which requires access credentials to access. The Sensu Enterprise
 packages install two processes: `sensu-enterprise` (which provides the Sensu
-server and API from a single process).
+server and API from a single process) and `sensu-client`.
 
 - [Install Sensu Enterprise on Ubuntu/Debian](../platforms/sensu-on-ubuntu-debian.html#sensu-enterprise)
 - [Install Sensu Enterprise on RHEL/CentOS](../platforms/sensu-on-rhel-centos.html#sensu-enterprise)


### PR DESCRIPTION
Text currently does not include the second process to be installed.
Proposed new sentence  adds " and `sensu-client`" to the sentence.

...install two processes: `sensu-enterprise` (which provides the Sensu
server and API from a single process) and `sensu-client`.
