### PR TITLE
[install] clarify SE provides server and API functions in one process

### DIFF
--- a/docs/0.23/installation/install-sensu-server-api.md
+++ b/docs/0.23/installation/install-sensu-server-api.md
@@ -47,8 +47,8 @@ Sensu Enterprise is installed via native system installer packages for
 Linux-based operating systems, only (i.e. .deb and .rpm). The Sensu Enterprise
 installer packages are made available via the Sensu Enterprise software
 repositories, which requires access credentials to access. The Sensu Enterprise
-packages installs a single process: `sensu-enterprise` (which provides the Sensu
-server and API from a single process).
+package installs a single executable, `sensu-enterprise`, which provides the
+functionality of Sensu server and API in a single process.
 
 - [Install Sensu Enterprise on Ubuntu/Debian](../platforms/sensu-on-ubuntu-debian.html#sensu-enterprise)
 - [Install Sensu Enterprise on RHEL/CentOS](../platforms/sensu-on-rhel-centos.html#sensu-enterprise)

--- a/docs/0.24/installation/install-sensu-server-api.md
+++ b/docs/0.24/installation/install-sensu-server-api.md
@@ -47,8 +47,8 @@ Sensu Enterprise is installed via native system installer packages for
 Linux-based operating systems, only (i.e. .deb and .rpm). The Sensu Enterprise
 installer packages are made available via the Sensu Enterprise software
 repositories, which requires access credentials to access. The Sensu Enterprise
-packages installs a single process: `sensu-enterprise` (which provides the Sensu
-server and API from a single process).
+package installs a single executable, `sensu-enterprise`, which provides the
+functionality of Sensu server and API in a single process.
 
 - [Install Sensu Enterprise on Ubuntu/Debian](../platforms/sensu-on-ubuntu-debian.html#sensu-enterprise)
 - [Install Sensu Enterprise on RHEL/CentOS](../platforms/sensu-on-rhel-centos.html#sensu-enterprise)

--- a/docs/0.25/installation/install-sensu-server-api.md
+++ b/docs/0.25/installation/install-sensu-server-api.md
@@ -47,8 +47,8 @@ Sensu Enterprise is installed via native system installer packages for
 Linux-based operating systems, only (i.e. .deb and .rpm). The Sensu Enterprise
 installer packages are made available via the Sensu Enterprise software
 repositories, which requires access credentials to access. The Sensu Enterprise
-packages installs a single process: `sensu-enterprise` (which provides the Sensu
-server and API from a single process).
+package installs a single executable, `sensu-enterprise`, which provides the
+functionality of Sensu server and API in a single process.
 
 - [Install Sensu Enterprise on Ubuntu/Debian](../platforms/sensu-on-ubuntu-debian.html#sensu-enterprise)
 - [Install Sensu Enterprise on RHEL/CentOS](../platforms/sensu-on-rhel-centos.html#sensu-enterprise)

--- a/docs/0.26/installation/install-sensu-server-api.md
+++ b/docs/0.26/installation/install-sensu-server-api.md
@@ -47,8 +47,8 @@ Sensu Enterprise is installed via native system installer packages for
 Linux-based operating systems, only (i.e. .deb and .rpm). The Sensu Enterprise
 installer packages are made available via the Sensu Enterprise software
 repositories, which requires access credentials to access. The Sensu Enterprise
-packages install two processes: `sensu-enterprise` (which provides the Sensu
-server and API from a single process).
+package installs a single executable, `sensu-enterprise`, which provides the
+functionality of Sensu server and API in a single process.
 
 - [Install Sensu Enterprise on Ubuntu/Debian](../platforms/sensu-on-ubuntu-debian.html#sensu-enterprise)
 - [Install Sensu Enterprise on RHEL/CentOS](../platforms/sensu-on-rhel-centos.html#sensu-enterprise)


### PR DESCRIPTION
As raised in #460, the current docs for installing server and API describe 

This change attempts to clarify that the sensu-enterprise package installs a single executable which provides both server and API functionality.

Closes #460 
