### PR TITLE
Fix getting started guide 'tranpsort' typo

### DIFF
--- a/docs/0.23/guides/getting-started/adding-a-client.md
+++ b/docs/0.23/guides/getting-started/adding-a-client.md
@@ -71,9 +71,9 @@ note the following steps that are required to add a remote Sensu client:
        "subscriptions": [
          "default",
          "webserver"
-       ]       
+       ]
      }
-   }   
+   }
    ~~~
 
 2. **Tell the client which transport to use**. Create a transport definition at
@@ -91,7 +91,7 @@ note the following steps that are required to add a remote Sensu client:
    }
    ~~~
 
-3. **Tell the client how to connect to the tranpsort**. Create a transport
+3. **Tell the client how to connect to the transport**. Create a transport
    definition at `/etc/sensu/conf.d/rabbitmq.json` (or
    `/etc/sensu/conf.d/redis.json` if you are using the Redis transport).
 

--- a/docs/0.24/guides/getting-started/adding-a-client.md
+++ b/docs/0.24/guides/getting-started/adding-a-client.md
@@ -71,9 +71,9 @@ note the following steps that are required to add a remote Sensu client:
        "subscriptions": [
          "default",
          "webserver"
-       ]       
+       ]
      }
-   }   
+   }
    ~~~
 
 2. **Tell the client which transport to use**. Create a transport definition at
@@ -91,7 +91,7 @@ note the following steps that are required to add a remote Sensu client:
    }
    ~~~
 
-3. **Tell the client how to connect to the tranpsort**. Create a transport
+3. **Tell the client how to connect to the transport**. Create a transport
    definition at `/etc/sensu/conf.d/rabbitmq.json` (or
    `/etc/sensu/conf.d/redis.json` if you are using the Redis transport).
 

--- a/docs/0.25/guides/getting-started/adding-a-client.md
+++ b/docs/0.25/guides/getting-started/adding-a-client.md
@@ -71,9 +71,9 @@ note the following steps that are required to add a remote Sensu client:
        "subscriptions": [
          "default",
          "webserver"
-       ]       
+       ]
      }
-   }   
+   }
    ~~~
 
 2. **Tell the client which transport to use**. Create a transport definition at
@@ -91,7 +91,7 @@ note the following steps that are required to add a remote Sensu client:
    }
    ~~~
 
-3. **Tell the client how to connect to the tranpsort**. Create a transport
+3. **Tell the client how to connect to the transport**. Create a transport
    definition at `/etc/sensu/conf.d/rabbitmq.json` (or
    `/etc/sensu/conf.d/redis.json` if you are using the Redis transport).
 

--- a/docs/0.26/guides/getting-started/adding-a-client.md
+++ b/docs/0.26/guides/getting-started/adding-a-client.md
@@ -91,7 +91,7 @@ note the following steps that are required to add a remote Sensu client:
    }
    ~~~
 
-3. **Tell the client how to connect to the tranpsort**. Create a transport
+3. **Tell the client how to connect to the transport**. Create a transport
    definition at `/etc/sensu/conf.d/rabbitmq.json` (or
    `/etc/sensu/conf.d/redis.json` if you are using the Redis transport).
 

--- a/docs/0.26/guides/getting-started/adding-a-client.md
+++ b/docs/0.26/guides/getting-started/adding-a-client.md
@@ -71,9 +71,9 @@ note the following steps that are required to add a remote Sensu client:
        "subscriptions": [
          "default",
          "webserver"
-       ]       
+       ]
      }
-   }   
+   }
    ~~~
 
 2. **Tell the client which transport to use**. Create a transport definition at


### PR DESCRIPTION
Extends #465 

Closes #465 