### PR TITLE
Fixed RABBITMQ_URL example vhost encoding for '/'

### DIFF
--- a/docs/0.23/reference/configuration.md
+++ b/docs/0.23/reference/configuration.md
@@ -687,7 +687,7 @@ environments.
   : false
 : example
   : ~~~ shell
-    RABBITMQ_URL="amqp://user:password@hostname:5672/vhost"
+    RABBITMQ_URL="amqp://user:password@hostname:5672/%2Fvhost"
     ~~~
 
 `REDIS_URL`

--- a/docs/0.24/reference/configuration.md
+++ b/docs/0.24/reference/configuration.md
@@ -703,7 +703,7 @@ environments.
   : false
 : example
   : ~~~ shell
-    RABBITMQ_URL="amqp://user:password@hostname:5672/vhost"
+    RABBITMQ_URL="amqp://user:password@hostname:5672/%2Fvhost"
     ~~~
 
 `REDIS_URL`

--- a/docs/0.25/reference/configuration.md
+++ b/docs/0.25/reference/configuration.md
@@ -703,7 +703,7 @@ environments.
   : false
 : example
   : ~~~ shell
-    RABBITMQ_URL="amqp://user:password@hostname:5672/vhost"
+    RABBITMQ_URL="amqp://user:password@hostname:5672/%2Fvhost"
     ~~~
 
 `REDIS_URL`

--- a/docs/0.26/reference/configuration.md
+++ b/docs/0.26/reference/configuration.md
@@ -703,7 +703,7 @@ environments.
   : false
 : example
   : ~~~ shell
-    RABBITMQ_URL="amqp://user:password@hostname:5672/vhost"
+    RABBITMQ_URL="amqp://user:password@hostname:5672/%2Fvhost"
     ~~~
 
 `REDIS_URL`

--- a/docs/0.27/reference/configuration.md
+++ b/docs/0.27/reference/configuration.md
@@ -703,7 +703,7 @@ environments.
   : false
 : example
   : ~~~ shell
-    RABBITMQ_URL="amqp://user:password@hostname:5672/vhost"
+    RABBITMQ_URL="amqp://user:password@hostname:5672/%2Fvhost"
     ~~~
 
 `REDIS_URL`

--- a/legacy/0.20/configuration.md
+++ b/legacy/0.20/configuration.md
@@ -625,7 +625,7 @@ RABBITMQ_URL
   : false
 : example
   : ~~~ shell
-    RABBITMQ_URL="amqp://user:password@hostname:5672/vhost"
+    RABBITMQ_URL="amqp://user:password@hostname:5672/%2Fvhost"
     ~~~
 
 REDIS_URL

--- a/legacy/0.21/configuration.md
+++ b/legacy/0.21/configuration.md
@@ -642,7 +642,7 @@ RABBITMQ_URL
   : false
 : example
   : ~~~ shell
-    RABBITMQ_URL="amqp://user:password@hostname:5672/vhost"
+    RABBITMQ_URL="amqp://user:password@hostname:5672/%2Fvhost"
     ~~~
 
 REDIS_URL

--- a/legacy/0.22/configuration.md
+++ b/legacy/0.22/configuration.md
@@ -642,7 +642,7 @@ RABBITMQ_URL
   : false
 : example
   : ~~~ shell
-    RABBITMQ_URL="amqp://user:password@hostname:5672/vhost"
+    RABBITMQ_URL="amqp://user:password@hostname:5672/%2Fvhost"
     ~~~
 
 REDIS_URL


### PR DESCRIPTION
Partial fix for https://github.com/sensu/sensu/issues/1518