### PR TITLE
Update repository configuration in legacy documentation

### DIFF
--- a/docs/0.23/platforms/sensu-on-rhel-centos.md
+++ b/docs/0.23/platforms/sensu-on-rhel-centos.md
@@ -57,7 +57,7 @@ configurations as shown below._
    ~~~ shell
    echo '[sensu]
    name=sensu
-   baseurl=http://sensu.global.ssl.fastly.net/yum/$releasever/$basearch/
+   baseurl=https://sensu.global.ssl.fastly.net/yum/$releasever/$basearch/
    gpgcheck=0
    enabled=1' | sudo tee /etc/yum.repos.d/sensu.repo
    ~~~

--- a/docs/0.23/platforms/sensu-on-rhel-centos.md
+++ b/docs/0.23/platforms/sensu-on-rhel-centos.md
@@ -46,13 +46,18 @@ package installs several processes including `sensu-server`, `sensu-api`, and
 
 ### Install Sensu using YUM (recommended) {#install-sensu-core-repository}
 
+_NOTE: As of January 2017, the yum repository URL has changed to
+include the `$releasever` variable. To install or upgrade to the
+latest version of Sensu, please ensure you have updated repository
+configurations as shown below._
+
 1. Create the YUM repository configuration file for the Sensu Core repository at
    `/etc/yum.repos.d/sensu.repo`:
 
    ~~~ shell
    echo '[sensu]
    name=sensu
-   baseurl=http://repositories.sensuapp.org/yum/$basearch/
+   baseurl=http://sensu.global.ssl.fastly.net/yum/$releasever/$basearch/
    gpgcheck=0
    enabled=1' | sudo tee /etc/yum.repos.d/sensu.repo
    ~~~

--- a/docs/0.23/platforms/sensu-on-ubuntu-debian.md
+++ b/docs/0.23/platforms/sensu-on-ubuntu-debian.md
@@ -30,7 +30,7 @@ info: "<strong>NOTE:</strong> this page contains reference documentation for
     - [Distributed configuration](#api-distributed-configuration)
   - [Example Sensu Enterprise Dashboard configurations](#example-sensu-enterprise-dashboard-configurations)
     - [Standalone configuration](#dashboard-standalone-configuration)
-    - [Distributed configuration](#dashboard-distributed-configuration)  
+    - [Distributed configuration](#dashboard-distributed-configuration)
   - [Enable the Sensu services to start on boot](#enable-the-sensu-services-to-start-on-boot)
   - [Disable the Sensu services on boot](#disable-the-sensu-services-on-boot)
 - [Operating Sensu](#operating-sensu)
@@ -46,25 +46,39 @@ Sensu Core package installs several processes including `sensu-server`,
 
 ### Install Sensu using APT (recommended) {#install-sensu-core-repository}
 
+_NOTE: As of January 2017, apt repository configuration has
+changed to include the "codename" of the Ubuntu/Debian release. To
+install or upgrade to the latest version of Sensu, please ensure you
+have updated existing repository configurations._
+
 1. Install the GPG public key:
 
    ~~~ shell
    wget -q https://sensu.global.ssl.fastly.net/apt/pubkey.gpg -O- | sudo apt-key add -
    ~~~
 
-2. Create an APT configuration file at `/etc/apt/sources.list.d/sensu.list`:
+2. Determine the codename of the Ubuntu/Debian release on your system:
 
    ~~~ shell
-   echo "deb     https://sensu.global.ssl.fastly.net/apt sensu main" | sudo tee /etc/apt/sources.list.d/sensu.list
+   . /etc/os-release && echo $VERSION
+   "14.04.4 LTS, Trusty Tahr" # codename for this system is "trusty"
    ~~~
 
-3. Update APT:
+3. Create an APT configuration file at
+   `/etc/apt/sources.list.d/sensu.list`:
+
+   ~~~ shell
+   export CODENAME=your_release_codename_here # e.g. "trusty"
+   echo "deb     https://sensu.global.ssl.fastly.net/apt $CODENAME main" | sudo tee /etc/apt/sources.list.d/sensu.list
+   ~~~
+
+4. Update APT:
 
    ~~~ shell
    sudo apt-get update
    ~~~
 
-4. Install Sensu:
+5. Install Sensu:
 
    ~~~ shell
    sudo apt-get install sensu
@@ -73,7 +87,7 @@ Sensu Core package installs several processes including `sensu-server`,
    _NOTE: as mentioned above, the `sensu` package installs all of the Sensu Core
    processes, including `sensu-client`, `sensu-server`, and `sensu-api`._
 
-5. Configure Sensu. **No "default" configuration is provided with Sensu**, so
+6. Configure Sensu. **No "default" configuration is provided with Sensu**, so
    none of the Sensu processes will run without the corresponding configuration.
    Please refer to the ["Configure Sensu" section][11] (below), for more
    information on configuring Sensu. **At minimum, all of the Sensu processes

--- a/docs/0.24/platforms/sensu-on-rhel-centos.md
+++ b/docs/0.24/platforms/sensu-on-rhel-centos.md
@@ -57,7 +57,7 @@ configurations as shown below._
    ~~~ shell
    echo '[sensu]
    name=sensu
-   baseurl=http://sensu.global.ssl.fastly.net/yum/$releasever/$basearch/
+   baseurl=https://sensu.global.ssl.fastly.net/yum/$releasever/$basearch/
    gpgcheck=0
    enabled=1' | sudo tee /etc/yum.repos.d/sensu.repo
    ~~~

--- a/docs/0.24/platforms/sensu-on-rhel-centos.md
+++ b/docs/0.24/platforms/sensu-on-rhel-centos.md
@@ -46,13 +46,18 @@ package installs several processes including `sensu-server`, `sensu-api`, and
 
 ### Install Sensu using YUM (recommended) {#install-sensu-core-repository}
 
+_NOTE: As of January 2017, the yum repository URL has changed to
+include the `$releasever` variable. To install or upgrade to the
+latest version of Sensu, please ensure you have updated repository
+configurations as shown below._
+
 1. Create the YUM repository configuration file for the Sensu Core repository at
    `/etc/yum.repos.d/sensu.repo`:
 
    ~~~ shell
    echo '[sensu]
    name=sensu
-   baseurl=https://sensu.global.ssl.fastly.net/yum/$basearch/
+   baseurl=http://sensu.global.ssl.fastly.net/yum/$releasever/$basearch/
    gpgcheck=0
    enabled=1' | sudo tee /etc/yum.repos.d/sensu.repo
    ~~~

--- a/docs/0.24/platforms/sensu-on-ubuntu-debian.md
+++ b/docs/0.24/platforms/sensu-on-ubuntu-debian.md
@@ -30,7 +30,7 @@ info: "<strong>NOTE:</strong> this page contains reference documentation for
     - [Distributed configuration](#api-distributed-configuration)
   - [Example Sensu Enterprise Dashboard configurations](#example-sensu-enterprise-dashboard-configurations)
     - [Standalone configuration](#dashboard-standalone-configuration)
-    - [Distributed configuration](#dashboard-distributed-configuration)  
+    - [Distributed configuration](#dashboard-distributed-configuration)
   - [Enable the Sensu services to start on boot](#enable-the-sensu-services-to-start-on-boot)
   - [Disable the Sensu services on boot](#disable-the-sensu-services-on-boot)
 - [Operating Sensu](#operating-sensu)
@@ -46,25 +46,39 @@ Sensu Core package installs several processes including `sensu-server`,
 
 ### Install Sensu using APT (recommended) {#install-sensu-core-repository}
 
+_NOTE: As of January 2017, apt repository configuration has
+changed to include the "codename" of the Ubuntu/Debian release. To
+install or upgrade to the latest version of Sensu, please ensure you
+have updated existing repository configurations._
+
 1. Install the GPG public key:
 
    ~~~ shell
    wget -q https://sensu.global.ssl.fastly.net/apt/pubkey.gpg -O- | sudo apt-key add -
    ~~~
 
-2. Create an APT configuration file at `/etc/apt/sources.list.d/sensu.list`:
+2. Determine the codename of the Ubuntu/Debian release on your system:
 
    ~~~ shell
-   echo "deb     https://sensu.global.ssl.fastly.net/apt sensu main" | sudo tee /etc/apt/sources.list.d/sensu.list
+   . /etc/os-release && echo $VERSION
+   "14.04.4 LTS, Trusty Tahr" # codename for this system is "trusty"
    ~~~
 
-3. Update APT:
+3. Create an APT configuration file at
+   `/etc/apt/sources.list.d/sensu.list`:
+
+   ~~~ shell
+   export CODENAME=your_release_codename_here # e.g. "trusty"
+   echo "deb     https://sensu.global.ssl.fastly.net/apt $CODENAME main" | sudo tee /etc/apt/sources.list.d/sensu.list
+   ~~~
+
+4. Update APT:
 
    ~~~ shell
    sudo apt-get update
    ~~~
 
-4. Install Sensu:
+5. Install Sensu:
 
    ~~~ shell
    sudo apt-get install sensu
@@ -73,7 +87,7 @@ Sensu Core package installs several processes including `sensu-server`,
    _NOTE: as mentioned above, the `sensu` package installs all of the Sensu Core
    processes, including `sensu-client`, `sensu-server`, and `sensu-api`._
 
-5. Configure Sensu. **No "default" configuration is provided with Sensu**, so
+6. Configure Sensu. **No "default" configuration is provided with Sensu**, so
    none of the Sensu processes will run without the corresponding configuration.
    Please refer to the ["Configure Sensu" section][11] (below), for more
    information on configuring Sensu. **At minimum, all of the Sensu processes

--- a/docs/0.25/platforms/sensu-on-rhel-centos.md
+++ b/docs/0.25/platforms/sensu-on-rhel-centos.md
@@ -57,7 +57,7 @@ configurations as shown below._
    ~~~ shell
    echo '[sensu]
    name=sensu
-   baseurl=http://sensu.global.ssl.fastly.net/yum/$releasever/$basearch/
+   baseurl=https://sensu.global.ssl.fastly.net/yum/$releasever/$basearch/
    gpgcheck=0
    enabled=1' | sudo tee /etc/yum.repos.d/sensu.repo
    ~~~

--- a/docs/0.25/platforms/sensu-on-rhel-centos.md
+++ b/docs/0.25/platforms/sensu-on-rhel-centos.md
@@ -46,13 +46,18 @@ package installs several processes including `sensu-server`, `sensu-api`, and
 
 ### Install Sensu using YUM (recommended) {#install-sensu-core-repository}
 
+_NOTE: As of January 2017, the yum repository URL has changed to
+include the `$releasever` variable. To install or upgrade to the
+latest version of Sensu, please ensure you have updated repository
+configurations as shown below._
+
 1. Create the YUM repository configuration file for the Sensu Core repository at
    `/etc/yum.repos.d/sensu.repo`:
 
    ~~~ shell
    echo '[sensu]
    name=sensu
-   baseurl=http://sensu.global.ssl.fastly.net/yum/$basearch/
+   baseurl=http://sensu.global.ssl.fastly.net/yum/$releasever/$basearch/
    gpgcheck=0
    enabled=1' | sudo tee /etc/yum.repos.d/sensu.repo
    ~~~

--- a/docs/0.25/platforms/sensu-on-ubuntu-debian.md
+++ b/docs/0.25/platforms/sensu-on-ubuntu-debian.md
@@ -30,7 +30,7 @@ info: "<strong>NOTE:</strong> this page contains reference documentation for
     - [Distributed configuration](#api-distributed-configuration)
   - [Example Sensu Enterprise Dashboard configurations](#example-sensu-enterprise-dashboard-configurations)
     - [Standalone configuration](#dashboard-standalone-configuration)
-    - [Distributed configuration](#dashboard-distributed-configuration)  
+    - [Distributed configuration](#dashboard-distributed-configuration)
   - [Enable the Sensu services to start on boot](#enable-the-sensu-services-to-start-on-boot)
   - [Disable the Sensu services on boot](#disable-the-sensu-services-on-boot)
 - [Operating Sensu](#operating-sensu)
@@ -46,25 +46,39 @@ Sensu Core package installs several processes including `sensu-server`,
 
 ### Install Sensu using APT (recommended) {#install-sensu-core-repository}
 
+_NOTE: As of January 2017, apt repository configuration has
+changed to include the "codename" of the Ubuntu/Debian release. To
+install or upgrade to the latest version of Sensu, please ensure you
+have updated existing repository configurations._
+
 1. Install the GPG public key:
 
    ~~~ shell
    wget -q https://sensu.global.ssl.fastly.net/apt/pubkey.gpg -O- | sudo apt-key add -
    ~~~
 
-2. Create an APT configuration file at `/etc/apt/sources.list.d/sensu.list`:
+2. Determine the codename of the Ubuntu/Debian release on your system:
 
    ~~~ shell
-   echo "deb     https://sensu.global.ssl.fastly.net/apt sensu main" | sudo tee /etc/apt/sources.list.d/sensu.list
+   . /etc/os-release && echo $VERSION
+   "14.04.4 LTS, Trusty Tahr" # codename for this system is "trusty"
    ~~~
 
-3. Update APT:
+3. Create an APT configuration file at
+   `/etc/apt/sources.list.d/sensu.list`:
+
+   ~~~ shell
+   export CODENAME=your_release_codename_here # e.g. "trusty"
+   echo "deb     https://sensu.global.ssl.fastly.net/apt $CODENAME main" | sudo tee /etc/apt/sources.list.d/sensu.list
+   ~~~
+
+4. Update APT:
 
    ~~~ shell
    sudo apt-get update
    ~~~
 
-4. Install Sensu:
+5. Install Sensu:
 
    ~~~ shell
    sudo apt-get install sensu
@@ -73,7 +87,7 @@ Sensu Core package installs several processes including `sensu-server`,
    _NOTE: as mentioned above, the `sensu` package installs all of the Sensu Core
    processes, including `sensu-client`, `sensu-server`, and `sensu-api`._
 
-5. Configure Sensu. **No "default" configuration is provided with Sensu**, so
+6. Configure Sensu. **No "default" configuration is provided with Sensu**, so
    none of the Sensu processes will run without the corresponding configuration.
    Please refer to the ["Configure Sensu" section][11] (below), for more
    information on configuring Sensu. **At minimum, all of the Sensu processes

--- a/docs/0.26/platforms/sensu-on-rhel-centos.md
+++ b/docs/0.26/platforms/sensu-on-rhel-centos.md
@@ -57,7 +57,7 @@ configurations as shown below._
    ~~~ shell
    echo '[sensu]
    name=sensu
-   baseurl=http://sensu.global.ssl.fastly.net/yum/$releasever/$basearch/
+   baseurl=https://sensu.global.ssl.fastly.net/yum/$releasever/$basearch/
    gpgcheck=0
    enabled=1' | sudo tee /etc/yum.repos.d/sensu.repo
    ~~~

--- a/docs/0.26/platforms/sensu-on-rhel-centos.md
+++ b/docs/0.26/platforms/sensu-on-rhel-centos.md
@@ -46,13 +46,18 @@ package installs several processes including `sensu-server`, `sensu-api`, and
 
 ### Install Sensu using YUM (recommended) {#install-sensu-core-repository}
 
+_NOTE: As of January 2017, the yum repository URL has changed to
+include the `$releasever` variable. To install or upgrade to the
+latest version of Sensu, please ensure you have updated repository
+configurations as shown below._
+
 1. Create the YUM repository configuration file for the Sensu Core repository at
    `/etc/yum.repos.d/sensu.repo`:
 
    ~~~ shell
    echo '[sensu]
    name=sensu
-   baseurl=http://sensu.global.ssl.fastly.net/yum/$basearch/
+   baseurl=http://sensu.global.ssl.fastly.net/yum/$releasever/$basearch/
    gpgcheck=0
    enabled=1' | sudo tee /etc/yum.repos.d/sensu.repo
    ~~~

--- a/docs/0.26/platforms/sensu-on-ubuntu-debian.md
+++ b/docs/0.26/platforms/sensu-on-ubuntu-debian.md
@@ -46,25 +46,39 @@ Sensu Core package installs several processes including `sensu-server`,
 
 ### Install Sensu using APT (recommended) {#install-sensu-core-repository}
 
+_NOTE: As of January 2017, apt repository configuration has
+changed to include the "codename" of the Ubuntu/Debian release. To
+install or upgrade to the latest version of Sensu, please ensure you
+have updated existing repository configurations._
+
 1. Install the GPG public key:
 
    ~~~ shell
    wget -q https://sensu.global.ssl.fastly.net/apt/pubkey.gpg -O- | sudo apt-key add -
    ~~~
 
-2. Create an APT configuration file at `/etc/apt/sources.list.d/sensu.list`:
+2. Determine the codename of the Ubuntu/Debian release on your system:
 
    ~~~ shell
-   echo "deb     https://sensu.global.ssl.fastly.net/apt sensu main" | sudo tee /etc/apt/sources.list.d/sensu.list
+   . /etc/os-release && echo $VERSION
+   "14.04.4 LTS, Trusty Tahr" # codename for this system is "trusty"
    ~~~
 
-3. Update APT:
+3. Create an APT configuration file at
+   `/etc/apt/sources.list.d/sensu.list`:
+
+   ~~~ shell
+   export CODENAME=your_release_codename_here # e.g. "trusty"
+   echo "deb     https://sensu.global.ssl.fastly.net/apt $CODENAME main" | sudo tee /etc/apt/sources.list.d/sensu.list
+   ~~~
+
+4. Update APT:
 
    ~~~ shell
    sudo apt-get update
    ~~~
 
-4. Install Sensu:
+5. Install Sensu:
 
    ~~~ shell
    sudo apt-get install sensu
@@ -73,7 +87,7 @@ Sensu Core package installs several processes including `sensu-server`,
    _NOTE: as mentioned above, the `sensu` package installs all of the Sensu Core
    processes, including `sensu-client`, `sensu-server`, and `sensu-api`._
 
-5. Configure Sensu. **No "default" configuration is provided with Sensu**, so
+6. Configure Sensu. **No "default" configuration is provided with Sensu**, so
    none of the Sensu processes will run without the corresponding configuration.
    Please refer to the ["Configure Sensu" section][11] (below), for more
    information on configuring Sensu. **At minimum, all of the Sensu processes

--- a/docs/0.27/platforms/sensu-on-rhel-centos.md
+++ b/docs/0.27/platforms/sensu-on-rhel-centos.md
@@ -58,7 +58,7 @@ repository configurations._
    ~~~ shell
    echo '[sensu]
    name=sensu
-   baseurl=http://sensu.global.ssl.fastly.net/yum/$releasever/$basearch/
+   baseurl=https://sensu.global.ssl.fastly.net/yum/$releasever/$basearch/
    gpgcheck=0
    enabled=1' | sudo tee /etc/yum.repos.d/sensu.repo
    ~~~

--- a/docs/0.27/platforms/sensu-on-ubuntu-debian.md
+++ b/docs/0.27/platforms/sensu-on-ubuntu-debian.md
@@ -64,7 +64,7 @@ have updated existing repository configurations._
    "14.04.4 LTS, Trusty Tahr" # codename for this system is "trusty"
    ~~~
 
-2. Create an APT configuration file at
+3. Create an APT configuration file at
    `/etc/apt/sources.list.d/sensu.list`:
 
    ~~~ shell
@@ -72,13 +72,13 @@ have updated existing repository configurations._
    echo "deb     https://sensu.global.ssl.fastly.net/apt $CODENAME main" | sudo tee /etc/apt/sources.list.d/sensu.list
    ~~~
 
-3. Update APT:
+4. Update APT:
 
    ~~~ shell
    sudo apt-get update
    ~~~
 
-4. Install Sensu:
+5. Install Sensu:
 
    ~~~ shell
    sudo apt-get install sensu
@@ -87,7 +87,7 @@ have updated existing repository configurations._
    _NOTE: as mentioned above, the `sensu` package installs all of the Sensu Core
    processes, including `sensu-client`, `sensu-server`, and `sensu-api`._
 
-5. Configure Sensu. **No "default" configuration is provided with Sensu**, so
+6. Configure Sensu. **No "default" configuration is provided with Sensu**, so
    none of the Sensu processes will run without the corresponding configuration.
    Please refer to the ["Configure Sensu" section][11] (below), for more
    information on configuring Sensu. **At minimum, all of the Sensu processes


### PR DESCRIPTION
As I understand it, the new repo configurations should still allow folks to install the packages for which we have legacy documentation. Hopefully this will reduce confusion for folks who inadvertently find their way to our older documentation.

Closes #511 