### PR TITLE
mark required attributes in check result specification

### DIFF
--- a/docs/0.23/reference/checks.md
+++ b/docs/0.23/reference/checks.md
@@ -199,6 +199,10 @@ _NOTE: Sensu check command tokens are also sometimes referred to as **"Sensu
 client overrides"**; a reference to the fact that command tokens allow client
 attributes to "override" [check command arguments][23]._
 
+_NOTE: Check tokens are processed before check execution, therefore token
+substitution will not apply to check data delivered via the local [client
+socket input][46]._
+
 ### Example check command tokens
 
 The following is an example Sensu [check definition][17] using two check command
@@ -740,6 +744,10 @@ thus able to be included in event notifications (e.g. email).
 See [check results][4] (above) for more information about check results,
 including an [example check result][37].
 
+Required attributes below are the minimum for check results submitted
+via the [client socket input][46]. Additional attributes are
+automatically added by the client to build a complete check result.
+
 #### `check` attributes {#check-result-check-attributes}
 
 `status`
@@ -748,6 +756,8 @@ including an [example check result][37].
     indicates `OK`, `1` indicates `WARNING`, and `2` indicates `CRITICAL`; exit
     status codes other than `0`, `1`, or `2` indicate an `UNKNOWN` or custom
     status.
+: required
+  : true
 : type
   : Integer
 : example
@@ -758,6 +768,8 @@ including an [example check result][37].
 `command`
 : description
   : The command as [provided by the check definition][17].
+: required
+  : false
 : type
   : String
 : example
@@ -768,6 +780,8 @@ including an [example check result][37].
 `subscribers`
 : description
   : The check subscribers as [provided by the check definition][17].
+: required
+  : false
 : type
   : Array
 : example
@@ -778,6 +792,8 @@ including an [example check result][37].
 `interval`
 : description
   : The check interval in seconds, as [provided by the check definition][17]
+: required
+  : false
 : type
   : Integer
 : example
@@ -788,6 +804,8 @@ including an [example check result][37].
 `name`
 : description
   : The check name, as [provided by the check definition][17]
+: required
+  : true
 : type
   : String
 : example
@@ -799,6 +817,8 @@ including an [example check result][37].
 : description
   : The time the check request was issued (by the [Sensu server][6] or
     [client][1]), stored as an integer (i.e. `Time.now.to_i`)
+: required
+  : false
 : type
   : Integer
 : example
@@ -810,6 +830,8 @@ including an [example check result][37].
 : description
   : The time the check request was executed by the [Sensu client][1], stored as
     and integer (i.e. `Time.now.to_i`).
+: required
+  : false
 : type
   : Integer
 : example
@@ -821,6 +843,8 @@ including an [example check result][37].
 : description
   : The amount of time (in seconds) it took for the [Sensu client][1] to execute
     the check.
+: required
+  : false
 : type
   : Float
 : example
@@ -831,6 +855,8 @@ including an [example check result][37].
 `output`
 : description
   : The output produced by the check `command`.
+: required
+  : true
 : type
   : String
 : example
@@ -899,3 +925,4 @@ including an [example check result][37].
 [41]: #check-names
 [42]: #subdue-attributes
 [43]: ../api/events-api.html#the-resolve-api-endpoint
+[46]: clients.html#client-socket-input

--- a/docs/0.24/reference/checks.md
+++ b/docs/0.24/reference/checks.md
@@ -202,6 +202,10 @@ tokens were also sometimes referred to as **"Sensu client overrides"**; a
 reference to the fact that command tokens allowed client attributes to
 "override" [check command arguments][23]._
 
+_NOTE: Check tokens are processed before check execution, therefore token
+substitution will not apply to check data delivered via the local [client
+socket input][46]._
+
 ### Example check tokens
 
 The following is an example Sensu [check definition][17] using three check
@@ -749,6 +753,10 @@ thus able to be included in event notifications (e.g. email).
 See [check results][4] (above) for more information about check results,
 including an [example check result][37].
 
+Required attributes below are the minimum for check results submitted
+via the [client socket input][46]. Additional attributes are
+automatically added by the client to build a complete check result.
+
 #### `check` attributes {#check-result-check-attributes}
 
 `status`
@@ -757,6 +765,8 @@ including an [example check result][37].
     indicates `OK`, `1` indicates `WARNING`, and `2` indicates `CRITICAL`; exit
     status codes other than `0`, `1`, or `2` indicate an `UNKNOWN` or custom
     status.
+: required
+  : true
 : type
   : Integer
 : example
@@ -767,6 +777,8 @@ including an [example check result][37].
 `command`
 : description
   : The command as [provided by the check definition][17].
+: required
+  : false
 : type
   : String
 : example
@@ -777,6 +789,8 @@ including an [example check result][37].
 `subscribers`
 : description
   : The check subscribers as [provided by the check definition][17].
+: required
+  : false
 : type
   : Array
 : example
@@ -787,6 +801,8 @@ including an [example check result][37].
 `interval`
 : description
   : The check interval in seconds, as [provided by the check definition][17]
+: required
+  : false
 : type
   : Integer
 : example
@@ -797,6 +813,8 @@ including an [example check result][37].
 `name`
 : description
   : The check name, as [provided by the check definition][17]
+: required
+  : true
 : type
   : String
 : example
@@ -808,6 +826,8 @@ including an [example check result][37].
 : description
   : The time the check request was issued (by the [Sensu server][6] or
     [client][1]), stored as an integer (i.e. `Time.now.to_i`)
+: required
+  : false
 : type
   : Integer
 : example
@@ -819,6 +839,8 @@ including an [example check result][37].
 : description
   : The time the check request was executed by the [Sensu client][1], stored as
     and integer (i.e. `Time.now.to_i`).
+: required
+  : false
 : type
   : Integer
 : example
@@ -830,6 +852,8 @@ including an [example check result][37].
 : description
   : The amount of time (in seconds) it took for the [Sensu client][1] to execute
     the check.
+: required
+  : false
 : type
   : Float
 : example
@@ -840,6 +864,8 @@ including an [example check result][37].
 `output`
 : description
   : The output produced by the check `command`.
+: required
+  : true
 : type
   : String
 : example
@@ -909,3 +935,4 @@ including an [example check result][37].
 [42]: #subdue-attributes
 [43]: /docs/0.24/overview/changelog.html
 [44]: ../api/events-api.html#the-resolve-api-endpoint
+[46]: clients.html#client-socket-input

--- a/docs/0.25/reference/checks.md
+++ b/docs/0.25/reference/checks.md
@@ -203,8 +203,8 @@ reference to the fact that command tokens allowed client attributes to
 "override" [check command arguments][23]._
 
 _NOTE: Check tokens are processed before check execution, therefore token
-substitution will not apply to check data delivered via the local TCP Sensu
-socket._
+substitution will not apply to check data delivered via the local [client
+socket input][46]._
 
 ### Example check tokens
 
@@ -784,6 +784,10 @@ thus able to be included in event notifications (e.g. email).
 See [check results][4] (above) for more information about check results,
 including an [example check result][37].
 
+Required attributes below are the minimum for check results submitted
+via the [client socket input][46]. Additional attributes are
+automatically added by the client to build a complete check result.
+
 #### `check` attributes {#check-result-check-attributes}
 
 `status`
@@ -792,6 +796,8 @@ including an [example check result][37].
     indicates `OK`, `1` indicates `WARNING`, and `2` indicates `CRITICAL`; exit
     status codes other than `0`, `1`, or `2` indicate an `UNKNOWN` or custom
     status.
+: required
+  : true
 : type
   : Integer
 : example
@@ -802,6 +808,8 @@ including an [example check result][37].
 `command`
 : description
   : The command as [provided by the check definition][17].
+: required
+  : false
 : type
   : String
 : example
@@ -812,6 +820,8 @@ including an [example check result][37].
 `subscribers`
 : description
   : The check subscribers as [provided by the check definition][17].
+: required
+  : false
 : type
   : Array
 : example
@@ -822,6 +832,8 @@ including an [example check result][37].
 `interval`
 : description
   : The check interval in seconds, as [provided by the check definition][17]
+: required
+  : false
 : type
   : Integer
 : example
@@ -832,6 +844,8 @@ including an [example check result][37].
 `name`
 : description
   : The check name, as [provided by the check definition][17]
+: required
+  : true
 : type
   : String
 : example
@@ -843,6 +857,8 @@ including an [example check result][37].
 : description
   : The time the check request was issued (by the [Sensu server][6] or
     [client][1]), stored as an integer (i.e. `Time.now.to_i`)
+: required
+  : false
 : type
   : Integer
 : example
@@ -854,6 +870,8 @@ including an [example check result][37].
 : description
   : The time the check request was executed by the [Sensu client][1], stored as
     and integer (i.e. `Time.now.to_i`).
+: required
+  : false
 : type
   : Integer
 : example
@@ -865,6 +883,8 @@ including an [example check result][37].
 : description
   : The amount of time (in seconds) it took for the [Sensu client][1] to execute
     the check.
+: required
+  : false
 : type
   : Float
 : example
@@ -875,6 +895,8 @@ including an [example check result][37].
 `output`
 : description
   : The output produced by the check `command`.
+: required
+  : true
 : type
   : String
 : example
@@ -945,3 +967,4 @@ including an [example check result][37].
 [43]: /docs/0.24/overview/changelog.html
 [44]: ../enterprise/contact-routing.html
 [45]: ../api/events-api.html#the-resolve-api-endpoint
+[46]: clients.html#client-socket-input

--- a/docs/0.26/reference/checks.md
+++ b/docs/0.26/reference/checks.md
@@ -203,8 +203,8 @@ reference to the fact that command tokens allowed client attributes to
 "override" [check command arguments][23]._
 
 _NOTE: Check tokens are processed before check execution, therefore token
-substitution will not apply to check data delivered via the local TCP Sensu
-socket._
+substitution will not apply to check data delivered via the local [client
+socket input][46]._
 
 ### Example check tokens
 
@@ -742,6 +742,10 @@ thus able to be included in event notifications (e.g. email).
 See [check results][4] (above) for more information about check results,
 including an [example check result][37].
 
+Required attributes below are the minimum for check results submitted
+via the [client socket input][46]. Additional attributes are
+automatically added by the client to build a complete check result.
+
 #### `check` attributes {#check-result-check-attributes}
 
 `status`
@@ -750,6 +754,8 @@ including an [example check result][37].
     indicates `OK`, `1` indicates `WARNING`, and `2` indicates `CRITICAL`; exit
     status codes other than `0`, `1`, or `2` indicate an `UNKNOWN` or custom
     status.
+: required
+  : true
 : type
   : Integer
 : example
@@ -760,6 +766,8 @@ including an [example check result][37].
 `command`
 : description
   : The command as [provided by the check definition][17].
+: required
+  : false
 : type
   : String
 : example
@@ -770,6 +778,8 @@ including an [example check result][37].
 `subscribers`
 : description
   : The check subscribers as [provided by the check definition][17].
+: required
+  : false
 : type
   : Array
 : example
@@ -780,6 +790,8 @@ including an [example check result][37].
 `interval`
 : description
   : The check interval in seconds, as [provided by the check definition][17]
+: required
+  : false
 : type
   : Integer
 : example
@@ -790,6 +802,8 @@ including an [example check result][37].
 `name`
 : description
   : The check name, as [provided by the check definition][17]
+: required
+  : true
 : type
   : String
 : example
@@ -801,6 +815,8 @@ including an [example check result][37].
 : description
   : The time the check request was issued (by the [Sensu server][6] or
     [client][1]), stored as an integer (i.e. `Time.now.to_i`)
+: required
+  : false
 : type
   : Integer
 : example
@@ -812,6 +828,8 @@ including an [example check result][37].
 : description
   : The time the check request was executed by the [Sensu client][1], stored as
     and integer (i.e. `Time.now.to_i`).
+: required
+  : false
 : type
   : Integer
 : example
@@ -823,6 +841,8 @@ including an [example check result][37].
 : description
   : The amount of time (in seconds) it took for the [Sensu client][1] to execute
     the check.
+: required
+  : false
 : type
   : Float
 : example
@@ -833,6 +853,8 @@ including an [example check result][37].
 `output`
 : description
   : The output produced by the check `command`.
+: required
+  : true
 : type
   : String
 : example
@@ -903,3 +925,4 @@ including an [example check result][37].
 [43]: /docs/0.24/overview/changelog.html
 [44]: ../enterprise/contact-routing.html
 [45]: ../api/events-api.html#the-resolve-api-endpoint
+[46]: clients.html#client-socket-input

--- a/docs/0.27/reference/checks.md
+++ b/docs/0.27/reference/checks.md
@@ -203,8 +203,8 @@ reference to the fact that command tokens allowed client attributes to
 "override" [check command arguments][23]._
 
 _NOTE: Check tokens are processed before check execution, therefore token
-substitution will not apply to check data delivered via the local TCP Sensu
-socket._
+substitution will not apply to check data delivered via the local [client
+socket input][46]._
 
 ### Example check tokens
 
@@ -742,6 +742,10 @@ thus able to be included in event notifications (e.g. email).
 See [check results][4] (above) for more information about check results,
 including an [example check result][37].
 
+Required attributes below are the minimum for check results submitted
+via the [client socket input][46]. Additional attributes are
+automatically added by the client to build a complete check result.
+
 #### `check` attributes {#check-result-check-attributes}
 
 `status`
@@ -750,6 +754,8 @@ including an [example check result][37].
     indicates `OK`, `1` indicates `WARNING`, and `2` indicates `CRITICAL`; exit
     status codes other than `0`, `1`, or `2` indicate an `UNKNOWN` or custom
     status.
+: required
+  : true
 : type
   : Integer
 : example
@@ -760,6 +766,8 @@ including an [example check result][37].
 `command`
 : description
   : The command as [provided by the check definition][17].
+: required
+  : false
 : type
   : String
 : example
@@ -770,6 +778,8 @@ including an [example check result][37].
 `subscribers`
 : description
   : The check subscribers as [provided by the check definition][17].
+: required
+  : false
 : type
   : Array
 : example
@@ -780,6 +790,8 @@ including an [example check result][37].
 `interval`
 : description
   : The check interval in seconds, as [provided by the check definition][17]
+: required
+  : false
 : type
   : Integer
 : example
@@ -790,6 +802,8 @@ including an [example check result][37].
 `name`
 : description
   : The check name, as [provided by the check definition][17]
+: required
+  : true
 : type
   : String
 : example
@@ -801,6 +815,8 @@ including an [example check result][37].
 : description
   : The time the check request was issued (by the [Sensu server][6] or
     [client][1]), stored as an integer (i.e. `Time.now.to_i`)
+: required
+  : false
 : type
   : Integer
 : example
@@ -812,6 +828,8 @@ including an [example check result][37].
 : description
   : The time the check request was executed by the [Sensu client][1], stored as
     and integer (i.e. `Time.now.to_i`).
+: required
+  : false
 : type
   : Integer
 : example
@@ -823,6 +841,8 @@ including an [example check result][37].
 : description
   : The amount of time (in seconds) it took for the [Sensu client][1] to execute
     the check.
+: required
+  : false
 : type
   : Float
 : example
@@ -833,6 +853,8 @@ including an [example check result][37].
 `output`
 : description
   : The output produced by the check `command`.
+: required
+  : true
 : type
   : String
 : example
@@ -903,3 +925,4 @@ including an [example check result][37].
 [43]: /docs/0.24/overview/changelog.html
 [44]: ../enterprise/contact-routing.html
 [45]: ../api/events-api.html#the-resolve-api-endpoint
+[46]: clients.html#client-socket-input


### PR DESCRIPTION
I noticed that the check result specification doesn't indicate whether or not attributes are required. 

I believe that `name`, `status` and `output` are the minimum attributes required for sending check results to the client socket input, so I think we should mark them as required in the spec.