### PR TITLE
[0.27/changelog] add note re: errors in upgrade from sysv to systemd

### DIFF
--- a/docs/0.27/overview/changelog.md
+++ b/docs/0.27/overview/changelog.md
@@ -67,7 +67,12 @@ This release includes potentially breaking, backwards-incompatible changes:
 	[platforms page][3] for links to updated installation instructions.
 
 - **NEW**: On platforms where systemd is the default init, Sensu now
-	packages systemd unit files instead of sysv init scripts.
+	provides systemd unit files instead of sysv init scripts.
+
+- **NOTE**: The transition of service management from sysv to systemd may
+	initially cause an error when restarting Sensu services. To
+	avoid this, please be sure to stop Sensu services before
+	upgrading to Sensu 0.27 and starting them again.
 
 - **REMOVED**: The embedded runit service supervisor is no longer included
 	in Sensu packages for Linux platforms.


### PR DESCRIPTION
As reported in https://github.com/sensu/sensu/issues/1569, the transition from sysv to systemd may leave sensu processes running under sysv init, which fail to start again under systemd, e.g. because ports are already bound by the existing process.

This change adds a note to indicate that this can be avoided by stopping sensu processes prior to 0.27 upgrade and then starting them again.