### PR TITLE
Fix broken links from 0.23 to 0.28 version

### DIFF
--- a/docs/0.23/quick-start/the-five-minute-install.md
+++ b/docs/0.23/quick-start/the-five-minute-install.md
@@ -179,7 +179,7 @@ the [installation guide](2).
    sudo /etc/init.d/sensu-enterprise start
    sudo /etc/init.d/sensu-enterprise-dashboard start
    sudo /etc/init.d/sensu-client start
-   ~~~   
+   ~~~
 
 10. Verify that your installation is ready to use by querying the Sensu API
     using the `curl` utility (and piping the result to the [`jq` utility][13]):
@@ -222,9 +222,9 @@ the [installation guide](2).
 
 
 [1]:  ../overview/architecture.html
-[2]:  ../guides/installation-guide/overview.html
-[3]:  ../guides/installation-guide/installation-strategies.html
-[4]:  ../guides/installation-guide/installation-strategies.html#standalone
+[2]:  ../installation/overview.html
+[3]:  ../installation/installation-strategies.html
+[4]:  ../installation/installation-strategies.html#standalone
 [5]:  http://releases.ubuntu.com/14.04/
 [6]:  http://github.com/sensu/sensu-bash
 [7]:  ../platforms/sensu-on-ubuntu-debian.html#install-sensu-core-repository

--- a/docs/0.24/quick-start/the-five-minute-install.md
+++ b/docs/0.24/quick-start/the-five-minute-install.md
@@ -179,7 +179,7 @@ the [installation guide](2).
    sudo /etc/init.d/sensu-enterprise start
    sudo /etc/init.d/sensu-enterprise-dashboard start
    sudo /etc/init.d/sensu-client start
-   ~~~   
+   ~~~
 
 10. Verify that your installation is ready to use by querying the Sensu API
     using the `curl` utility (and piping the result to the [`jq` utility][13]):
@@ -222,9 +222,9 @@ the [installation guide](2).
 
 
 [1]:  ../overview/architecture.html
-[2]:  ../guides/installation-guide/overview.html
-[3]:  ../guides/installation-guide/installation-strategies.html
-[4]:  ../guides/installation-guide/installation-strategies.html#standalone
+[2]:  ../installation/overview.html
+[3]:  ../installation/installation-strategies.html
+[4]:  ../installation/installation-strategies.html#standalone
 [5]:  http://releases.ubuntu.com/14.04/
 [6]:  http://github.com/sensu/sensu-bash
 [7]:  ../platforms/sensu-on-ubuntu-debian.html#install-sensu-core-repository

--- a/docs/0.25/quick-start/the-five-minute-install.md
+++ b/docs/0.25/quick-start/the-five-minute-install.md
@@ -179,7 +179,7 @@ the [installation guide](2).
    sudo /etc/init.d/sensu-enterprise start
    sudo /etc/init.d/sensu-enterprise-dashboard start
    sudo /etc/init.d/sensu-client start
-   ~~~   
+   ~~~
 
 10. Verify that your installation is ready to use by querying the Sensu API
     using the `curl` utility (and piping the result to the [`jq` utility][13]):
@@ -222,9 +222,9 @@ the [installation guide](2).
 
 
 [1]:  ../overview/architecture.html
-[2]:  ../guides/installation-guide/overview.html
-[3]:  ../guides/installation-guide/installation-strategies.html
-[4]:  ../guides/installation-guide/installation-strategies.html#standalone
+[2]:  ../installation/overview.html
+[3]:  ../installation/installation-strategies.html
+[4]:  ../installation/installation-strategies.html#standalone
 [5]:  http://releases.ubuntu.com/14.04/
 [6]:  http://github.com/sensu/sensu-bash
 [7]:  ../platforms/sensu-on-ubuntu-debian.html#install-sensu-core-repository

--- a/docs/0.26/quick-start/the-five-minute-install.md
+++ b/docs/0.26/quick-start/the-five-minute-install.md
@@ -222,9 +222,9 @@ the [installation guide](2).
 
 
 [1]:  ../overview/architecture.html
-[2]:  ../guides/installation-guide/overview.html
-[3]:  ../guides/installation-guide/installation-strategies.html
-[4]:  ../guides/installation-guide/installation-strategies.html#standalone
+[2]:  ../installation/overview.html
+[3]:  ../installation/installation-strategies.html
+[4]:  ../installation/installation-strategies.html#standalone
 [5]:  http://releases.ubuntu.com/14.04/
 [6]:  http://github.com/sensu/sensu-bash
 [7]:  ../platforms/sensu-on-ubuntu-debian.html#install-sensu-core-repository

--- a/docs/0.27/quick-start/the-five-minute-install.md
+++ b/docs/0.27/quick-start/the-five-minute-install.md
@@ -222,9 +222,9 @@ the [installation guide](2).
 
 
 [1]:  ../overview/architecture.html
-[2]:  ../guides/installation-guide/overview.html
-[3]:  ../guides/installation-guide/installation-strategies.html
-[4]:  ../guides/installation-guide/installation-strategies.html#standalone
+[2]:  ../installation/overview.html
+[3]:  ../installation/installation-strategies.html
+[4]:  ../installation/installation-strategies.html#standalone
 [5]:  http://releases.ubuntu.com/14.04/
 [6]:  http://github.com/sensu/sensu-bash
 [7]:  ../platforms/sensu-on-ubuntu-debian.html#install-sensu-core-repository

--- a/docs/0.28/quick-start/the-five-minute-install.md
+++ b/docs/0.28/quick-start/the-five-minute-install.md
@@ -222,9 +222,9 @@ the [installation guide](2).
 
 
 [1]:  ../overview/architecture.html
-[2]:  ../guides/installation-guide/overview.html
-[3]:  ../guides/installation-guide/installation-strategies.html
-[4]:  ../guides/installation-guide/installation-strategies.html#standalone
+[2]:  ../installation/overview.html
+[3]:  ../installation/installation-strategies.html
+[4]:  ../installation/installation-strategies.html#standalone
 [5]:  http://releases.ubuntu.com/14.04/
 [6]:  http://github.com/sensu/sensu-bash
 [7]:  ../platforms/sensu-on-ubuntu-debian.html#install-sensu-core-repository

--- a/legacy/0.22/the-five-minute-install.md
+++ b/legacy/0.22/the-five-minute-install.md
@@ -179,7 +179,7 @@ the [installation guide][2].
    sudo /etc/init.d/sensu-enterprise start
    sudo /etc/init.d/sensu-enterprise-dashboard start
    sudo /etc/init.d/sensu-client start
-   ~~~   
+   ~~~
 
 10. Verify that your installation is ready to use by querying the Sensu API
     using the `curl` utility (and piping the result to the [`jq` utility][13]):
@@ -224,7 +224,7 @@ the [installation guide][2].
 [1]:  architecture
 [2]:  installation-guide
 [3]:  installation-strategies
-[4]:  installation-strategies#standalone
+[4]:  installation-guide
 [5]:  http://releases.ubuntu.com/14.04/
 [6]:  http://github.com/sensu/sensu-bash
 [7]:  sensu-on-ubuntu-debian#install-sensu-core-repository


### PR DESCRIPTION
# Changelog

Fixing some broken links that link to [Installation Guide](https://sensuapp.org/docs/0.28/quick-start/)

**Pages with broken links**

[Latest Version](https://sensuapp.org/docs/latest/quick-start/the-five-minute-install.html)
[0.28 Version](https://sensuapp.org/docs/0.28/quick-start/the-five-minute-install.html)
[0.27 Version](https://sensuapp.org/docs/0.27/quick-start/the-five-minute-install.html)
[0.26 Version](https://sensuapp.org/docs/0.26/quick-start/the-five-minute-install.html)
[0.25 Version](https://sensuapp.org/docs/0.25/quick-start/the-five-minute-install.html)
[0.24 Version](https://sensuapp.org/docs/0.24/quick-start/the-five-minute-install.html)
[0.23 Version](https://sensuapp.org/docs/0.23/quick-start/the-five-minute-install.html)