### PR TITLE
Clarify proxy client:normal client relationship

### DIFF
--- a/docs/0.28/guides/getting-started/adding-a-client.md
+++ b/docs/0.28/guides/getting-started/adding-a-client.md
@@ -7,6 +7,10 @@ next:
   text: "An intro to checks"
 ---
 
+**Sensu clients** are pieces of infrastructure that Sensu monitors for you. The **Sensu client software** allows you to register a running instance of itself as capable of running any **checks** they might be eligible for.
+
+Infrastructure sometimes includes hardware or services that don't necessarily support running the **Sensu client software** but still needs to be monitored. For those cases, [**proxy clients**](#proxy-clients) let you monitor anything you can tell Sensu about.
+
 # Adding a Sensu Client
 
 One of the first challenges new Sensu users often encounter is learning what
@@ -110,6 +114,12 @@ note the following steps that are required to add a remote Sensu client:
    sudo service sensu-client start
    ~~~
 
+## Proxy Clients
+
+Sometimes, a logical piece of infrastructure isn't a device we can run Sensu on. Fundamentally, Sensu gives you the flexibility to separate **how** checks run from **where** they run, which lets you monitor arbitrary, named 'black box' devices or services.
+
+For example, you may have a router that you can't run Sensu on but publishes interesting information over SNMP that you want to gather metrics from. Or maybe your monitor which other datacenters are visible/online to you, or have any number of creative use cases. You can create a [**proxy client**][16] that can have attributes for use in check execution, allowing you to use the **client registry** naturally for 'managed' an 'unmanaged' infrastructure. See [the reference for creating proxy clients][16] or [details on writing checks against them][17] for more.
+
 ## Troubleshooting
 
 
@@ -129,3 +139,5 @@ note the following steps that are required to add a remote Sensu client:
 [13]: ../../reference/redis.html
 [14]: ../../reference/clients.html#client-keepalives
 [15]: ../../reference/checks.html#check-results
+[16]: ../../reference/clients.html#proxy-clients
+[17]: intro-to-checks.html#proxy-clients

--- a/docs/0.28/guides/getting-started/intro-to-checks.md
+++ b/docs/0.28/guides/getting-started/intro-to-checks.md
@@ -277,7 +277,7 @@ sudo sensu-install -p graphite:0.0.6
 ~~~
 
 ## Checking on Other Clients {#proxy-clients}
-Sensu supports running checks where the results are considered to be for a **client** that isn't actually the one **executing** the check- regardless of whether that client is a **Sensu client** or simply a **proxy client**. There are a number of reasons for this use case, but fundamentally, Sensu handles it the same.
+Sensu supports running checks where the results are considered to be for a **client** that isn't actually the one **executing** the check- regardless of whether that client is a **Sensu client** or simply a [**proxy client**][14]. There are a number of reasons for this use case, but fundamentally, Sensu handles it the same.
 
 Checks are scheduled normally, but by specifying a [**Proxy Request**][13] in your check, clients that match certain definitions (their `client_attributes`) cause the check to run for each one. The attributes supplied must normally match *exactly* as stated- no variables or directives have any special meaning, but you can still use `eval` to perform more complicated filtering with Ruby on the available `value`, such as finding clients with particular subscriptions (given that we're dealing with arrays):
 
@@ -304,3 +304,4 @@ Checks are scheduled normally, but by specifying a [**Proxy Request**][13] in yo
 [11]: #metric-collection-checks
 [12]: https://github.com/sensu-plugins/sensu-plugins-graphite
 [13]: ../../reference/checks.html#proxy-requests-attributes
+[14]: adding-a-client.html#proxy-clients

--- a/docs/0.28/guides/getting-started/intro-to-checks.md
+++ b/docs/0.28/guides/getting-started/intro-to-checks.md
@@ -276,6 +276,21 @@ script.
 sudo sensu-install -p graphite:0.0.6
 ~~~
 
+## Checking on Other Clients {#proxy-clients}
+Sensu supports running checks where the results are considered to be for a **client** that isn't actually the one **executing** the check- regardless of whether that client is a **Sensu client** or simply a **proxy client**. There are a number of reasons for this use case, but fundamentally, Sensu handles it the same.
+
+Checks are scheduled normally, but by specifying a [**Proxy Request**][13] in your check, clients that match certain definitions (their `client_attributes`) cause the check to run for each one. The attributes supplied must normally match *exactly* as stated- no variables or directives have any special meaning, but you can still use `eval` to perform more complicated filtering with Ruby on the available `value`, such as finding clients with particular subscriptions (given that we're dealing with arrays):
+
+```json
+  "proxy_requests"{
+    "client_attributes": {
+      "user_variable": "some_value",
+      "subscriptions":
+        "eval: value.include?('a_subscription')"
+    }
+  }
+```
+
 [1]:  ../../reference/checks.html
 [2]:  https://github.com/sensu-plugins/sensu-plugins-process-checks
 [3]:  #check-cron-install-dependencies
@@ -288,3 +303,4 @@ sudo sensu-install -p graphite:0.0.6
 [10]: ../../reference/events.html#what-are-sensu-events
 [11]: #metric-collection-checks
 [12]: https://github.com/sensu-plugins/sensu-plugins-graphite
+[13]: ../../reference/checks.html#proxy-requests-attributes

--- a/docs/0.28/overview/how-sensu-works.md
+++ b/docs/0.28/overview/how-sensu-works.md
@@ -20,7 +20,7 @@ next:
 - **Service Checks** emit status information and telemetry data as **Check
   Results**
 - **Check Results** are considered to be associated with either the **Sensu Client** executing the check or the **Proxy Client** of the check
-- Those **Check Results** are published by the **Source** to the **Sensu Transport**
+- Those **Check Results** are published by the **Sensu Client** to the **Sensu Transport**, sometimes on behalf of another client
 - The **Sensu Server** processes **Check Results**, persisting a copy of the
   latest result in the **Data Store** and creating a corresponding to **Event**
 - The **Sensu Server** processes the **Event** by executing one or more **Event

--- a/docs/0.28/overview/how-sensu-works.md
+++ b/docs/0.28/overview/how-sensu-works.md
@@ -19,8 +19,8 @@ next:
 - The **Sensu Client** executes a **Service Check**
 - **Service Checks** emit status information and telemetry data as **Check
   Results**
-- **Check Results** are published by the **Sensu Client** to the **Sensu
-  Transport**
+- **Check Results** are considered to be associated with either the **Sensu Client** executing the check or the **Proxy Client** of the check
+- Those **Check Results** are published by the **Sensu Client** to the **Sensu Transport**
 - The **Sensu Server** processes **Check Results**, persisting a copy of the
   latest result in the **Data Store** and creating a corresponding to **Event**
 - The **Sensu Server** processes the **Event** by executing one or more **Event

--- a/docs/0.28/overview/how-sensu-works.md
+++ b/docs/0.28/overview/how-sensu-works.md
@@ -20,7 +20,7 @@ next:
 - **Service Checks** emit status information and telemetry data as **Check
   Results**
 - **Check Results** are considered to be associated with either the **Sensu Client** executing the check or the **Proxy Client** of the check
-- Those **Check Results** are published by the **Sensu Client** to the **Sensu Transport**
+- Those **Check Results** are published by the **Source** to the **Sensu Transport**
 - The **Sensu Server** processes **Check Results**, persisting a copy of the
   latest result in the **Data Store** and creating a corresponding to **Event**
 - The **Sensu Server** processes the **Event** by executing one or more **Event

--- a/docs/0.28/reference/checks.md
+++ b/docs/0.28/reference/checks.md
@@ -783,6 +783,8 @@ check `source` is set to the client `name`.
     }
     ~~~
 
+    You can, as above, also use `eval` to perform more complicated filtering with Ruby on the available `value`, such as finding clients with particular subscriptions.
+
 #### Custom attributes
 
 Because Sensu configuration is just JSON data, it is possible to define

--- a/docs/0.28/reference/checks.md
+++ b/docs/0.28/reference/checks.md
@@ -783,7 +783,9 @@ check `source` is set to the client `name`.
     }
     ~~~
 
-    You can, as above, also use `eval` to perform more complicated filtering with Ruby on the available `value`, such as finding clients with particular subscriptions.
+You can, as above, also use `eval` to perform more complicated filtering with Ruby on the available `value`, such as finding clients with particular subscriptions.
+
+For a more general introduction to using this style of check, check out the [guide on using proxy checks][49] or the [guide on adding a proxy client][50].
 
 #### Custom attributes
 
@@ -1010,3 +1012,5 @@ automatically added by the client to build a complete check result.
 [46]: clients.html#client-socket-input
 [47]: https://en.wikipedia.org/wiki/Cron#CRON_expression
 [48]: #proxy-requests-attributes
+[49]: ../guides/getting-started/intro-to-checks.html#proxy-clients
+[50]: ../guides/getting-started/adding-a-client.html#proxy-clients


### PR DESCRIPTION
- Emphasizes that proxy clients are normal clients with nuances around how they're selected
- This should address most of #528
- Possibly requires more explanation of using interpolation with variables from proxy clients that match; finding additional reference