### PR TITLE
[check reference] remove assertion that custom attrs can influence handlers or commands

### DIFF
--- a/docs/0.23/reference/checks.md
+++ b/docs/0.23/reference/checks.md
@@ -707,15 +707,14 @@ name][41]).
 
 #### Custom attributes
 
-Because Sensu configuration is just JSON data, it is possible to define
+Because Sensu configuration is simply JSON data, it is possible to define
 configuration attributes that are not part of the Sensu [check definition
-specification][17]. Custom check definition attributes may be defined to provide
-context about the check, or to control or modify check `command` or `handler`
-behaviors. Custom check definition attributes will be included in [check
-results][4] and [event data][40]. Some great example use cases for custom check
-definition attributes are links to playbook documentation (i.e. "here's a link
-to some instructions for how to fix this if it's broken"), [contact
-routing][36], and metric graph image URLs.
+specification][17]. These custom check attributes are included in
+[check results][4] and [event data][40], providing additional context
+about the check. Some great example use cases for custom check
+definition attributes are links to playbook documentation
+(i.e. "here's a link to some instructions for how to fix this if it's
+broken"), [contact routing][36], and metric graph image URLs.
 
 ##### EXAMPLE
 

--- a/docs/0.24/reference/checks.md
+++ b/docs/0.24/reference/checks.md
@@ -716,15 +716,14 @@ name][41]).
 
 #### Custom attributes
 
-Because Sensu configuration is just JSON data, it is possible to define
+Because Sensu configuration is simply JSON data, it is possible to define
 configuration attributes that are not part of the Sensu [check definition
-specification][17]. Custom check definition attributes may be defined to provide
-context about the check, or to control or modify check `command` or `handler`
-behaviors. Custom check definition attributes will be included in [check
-results][4] and [event data][40]. Some great example use cases for custom check
-definition attributes are links to playbook documentation (i.e. "here's a link
-to some instructions for how to fix this if it's broken"), [contact
-routing][36], and metric graph image URLs.
+specification][17]. These custom check attributes are included in
+[check results][4] and [event data][40], providing additional context
+about the check. Some great example use cases for custom check
+definition attributes are links to playbook documentation
+(i.e. "here's a link to some instructions for how to fix this if it's
+broken"), [contact routing][36], and metric graph image URLs.
 
 ##### EXAMPLE
 

--- a/docs/0.25/reference/checks.md
+++ b/docs/0.25/reference/checks.md
@@ -747,15 +747,14 @@ name][41]).
 
 #### Custom attributes
 
-Because Sensu configuration is just JSON data, it is possible to define
+Because Sensu configuration is simply JSON data, it is possible to define
 configuration attributes that are not part of the Sensu [check definition
-specification][17]. Custom check definition attributes may be defined to provide
-context about the check, or to control or modify check `command` or `handler`
-behaviors. Custom check definition attributes will be included in [check
-results][4] and [event data][40]. Some great example use cases for custom check
-definition attributes are links to playbook documentation (i.e. "here's a link
-to some instructions for how to fix this if it's broken"), [contact
-routing][36], and metric graph image URLs.
+specification][17]. These custom check attributes are included in
+[check results][4] and [event data][40], providing additional context
+about the check. Some great example use cases for custom check
+definition attributes are links to playbook documentation
+(i.e. "here's a link to some instructions for how to fix this if it's
+broken"), [contact routing][36], and metric graph image URLs.
 
 ##### EXAMPLE
 

--- a/docs/0.26/reference/checks.md
+++ b/docs/0.26/reference/checks.md
@@ -705,15 +705,14 @@ name][41]).
 
 #### Custom attributes
 
-Because Sensu configuration is just JSON data, it is possible to define
+Because Sensu configuration is simply JSON data, it is possible to define
 configuration attributes that are not part of the Sensu [check definition
-specification][17]. Custom check definition attributes may be defined to provide
-context about the check, or to control or modify check `command` or `handler`
-behaviors. Custom check definition attributes will be included in [check
-results][4] and [event data][40]. Some great example use cases for custom check
-definition attributes are links to playbook documentation (i.e. "here's a link
-to some instructions for how to fix this if it's broken"), [contact
-routing][36], and metric graph image URLs.
+specification][17]. These custom check attributes are included in
+[check results][4] and [event data][40], providing additional context
+about the check. Some great example use cases for custom check
+definition attributes are links to playbook documentation
+(i.e. "here's a link to some instructions for how to fix this if it's
+broken"), [contact routing][36], and metric graph image URLs.
 
 ##### EXAMPLE
 

--- a/docs/0.27/reference/checks.md
+++ b/docs/0.27/reference/checks.md
@@ -705,15 +705,14 @@ name][41]).
 
 #### Custom attributes
 
-Because Sensu configuration is just JSON data, it is possible to define
+Because Sensu configuration is simply JSON data, it is possible to define
 configuration attributes that are not part of the Sensu [check definition
-specification][17]. Custom check definition attributes may be defined to provide
-context about the check, or to control or modify check `command` or `handler`
-behaviors. Custom check definition attributes will be included in [check
-results][4] and [event data][40]. Some great example use cases for custom check
-definition attributes are links to playbook documentation (i.e. "here's a link
-to some instructions for how to fix this if it's broken"), [contact
-routing][36], and metric graph image URLs.
+specification][17]. These custom check attributes are included in
+[check results][4] and [event data][40], providing additional context
+about the check. Some great example use cases for custom check
+definition attributes are links to playbook documentation
+(i.e. "here's a link to some instructions for how to fix this if it's
+broken"), [contact routing][36], and metric graph image URLs.
 
 ##### EXAMPLE
 

--- a/docs/0.28/reference/checks.md
+++ b/docs/0.28/reference/checks.md
@@ -789,15 +789,14 @@ For a more general introduction to using this style of check, check out the [gui
 
 #### Custom attributes
 
-Because Sensu configuration is just JSON data, it is possible to define
+Because Sensu configuration is simply JSON data, it is possible to define
 configuration attributes that are not part of the Sensu [check definition
-specification][17]. Custom check definition attributes may be defined to provide
-context about the check, or to control or modify check `command` or `handler`
-behaviors. Custom check definition attributes will be included in [check
-results][4] and [event data][40]. Some great example use cases for custom check
-definition attributes are links to playbook documentation (i.e. "here's a link
-to some instructions for how to fix this if it's broken"), [contact
-routing][36], and metric graph image URLs.
+specification][17]. These custom check attributes are included in
+[check results][4] and [event data][40], providing additional context
+about the check. Some great example use cases for custom check
+definition attributes are links to playbook documentation
+(i.e. "here's a link to some instructions for how to fix this if it's
+broken"), [contact routing][36], and metric graph image URLs.
 
 ##### EXAMPLE
 

--- a/docs/0.29/reference/checks.md
+++ b/docs/0.29/reference/checks.md
@@ -789,15 +789,14 @@ For a more general introduction to using this style of check, check out the [gui
 
 #### Custom attributes
 
-Because Sensu configuration is just JSON data, it is possible to define
+Because Sensu configuration is simply JSON data, it is possible to define
 configuration attributes that are not part of the Sensu [check definition
-specification][17]. Custom check definition attributes may be defined to provide
-context about the check, or to control or modify check `command` or `handler`
-behaviors. Custom check definition attributes will be included in [check
-results][4] and [event data][40]. Some great example use cases for custom check
-definition attributes are links to playbook documentation (i.e. "here's a link
-to some instructions for how to fix this if it's broken"), [contact
-routing][36], and metric graph image URLs.
+specification][17]. These custom check attributes are included in
+[check results][4] and [event data][40], providing additional context
+about the check. Some great example use cases for custom check
+definition attributes are links to playbook documentation
+(i.e. "here's a link to some instructions for how to fix this if it's
+broken"), [contact routing][36], and metric graph image URLs.
 
 ##### EXAMPLE
 


### PR DESCRIPTION
Rewording section on custom check attributes to remove text which indicates custom check attributes can influence check `command` attribute or handler behavior.

See https://github.com/sensu/sensu/issues/1586 for my thoughts on why this assertion is more or less incorrect.

Closes #519 