### PR TITLE
Update weights and overview page links for 0.29 api docs.

### DIFF
--- a/docs/0.29/api/configuration.md
+++ b/docs/0.29/api/configuration.md
@@ -1,7 +1,7 @@
 ---
 title: "API Configuration"
 version: 0.29
-weight: 9
+weight: 10
 info: "<strong>NOTE:</strong> Please visit the <a href='../enterprise/api.html'>
   Sensu Enterprise API reference documentation</a> for information on
   configuring the Sensu Enterprise API (including native SSL encryption)."

--- a/docs/0.29/api/overview.md
+++ b/docs/0.29/api/overview.md
@@ -28,6 +28,7 @@ willingness to Google) industry standard RESTful API behaviors &ndash; including
 - [Events API](events-api.html)
 - [Stashes API](stashes-api.html)
 - [Health & Info API](health-and-info-api.html)
+- [Settings API](settings-api.html)
 - [API configuration](configuration.html)
 
 ## Response Content Filtering

--- a/docs/0.29/api/settings-api.md
+++ b/docs/0.29/api/settings-api.md
@@ -1,7 +1,7 @@
 ---
 title: "Settings API"
 version: 0.29
-weight: 8
+weight: 9
 next:
   url: "configuration.html"
   text: "API Configuration"


### PR DESCRIPTION
While going through the docs at [0.29/api/overview](https://sensuapp.org/docs/0.29/api/overview.html) I noticed that some things were slightly off.
This is a trivial update of links and weights. I'd like to add more, but really need to get more familiar with the API first.
I'm idling in the IRC as qayshp if anyone wants to chat.