### PR TITLE
[installation] set weight of 8 for upgrading doc

### DIFF
--- a/docs/0.23/installation/upgrading.md
+++ b/docs/0.23/installation/upgrading.md
@@ -2,6 +2,7 @@
 version: 0.23
 category: "Upgrading Guide"
 title: "Upgrading Sensu"
+weight: 8
 ---
 
 # Upgrading Sensu

--- a/docs/0.24/installation/upgrading.md
+++ b/docs/0.24/installation/upgrading.md
@@ -2,6 +2,7 @@
 version: 0.24
 category: "Upgrading Guide"
 title: "Upgrading Sensu"
+weight: 8
 ---
 
 # Upgrading Sensu

--- a/docs/0.25/installation/upgrading.md
+++ b/docs/0.25/installation/upgrading.md
@@ -2,6 +2,7 @@
 version: 0.25
 category: "Upgrading Guide"
 title: "Upgrading Sensu"
+weight: 8
 ---
 
 # Upgrading Sensu

--- a/docs/0.26/installation/upgrading.md
+++ b/docs/0.26/installation/upgrading.md
@@ -2,6 +2,7 @@
 version: 0.26
 category: "Upgrading Guide"
 title: "Upgrading Sensu"
+weight: 8
 ---
 
 # Upgrading Sensu

--- a/docs/0.27/installation/upgrading.md
+++ b/docs/0.27/installation/upgrading.md
@@ -2,6 +2,7 @@
 version: 0.28
 category: "Upgrading Guide"
 title: "Upgrading Sensu"
+weight: 8
 ---
 
 # Upgrading Sensu

--- a/docs/0.28/installation/upgrading.md
+++ b/docs/0.28/installation/upgrading.md
@@ -2,6 +2,7 @@
 version: 0.28
 category: "Upgrading Guide"
 title: "Upgrading Sensu"
+weight: 8
 ---
 
 # Upgrading Sensu

--- a/docs/0.29/installation/upgrading.md
+++ b/docs/0.29/installation/upgrading.md
@@ -2,6 +2,7 @@
 version: 0.29
 category: "Upgrading Guide"
 title: "Upgrading Sensu"
+weight: 8
 ---
 
 # Upgrading Sensu
@@ -10,7 +11,7 @@ _WARNING: Note that the biggest change in this release that may affect your
 deployment deals with our internal update to a newer Ruby. This means
 that plugins will have to be re-installed - and any old plugins will
 continue to persist on your filesystem._
- 
+
 Upgrading Sensu is usually a straightforward process. In most cases,
 upgrading Sensu and/or Sensu Enterprise only requires upgrading to the
 latest package. Certain versions of Sensu may include changes that are


### PR DESCRIPTION
When I brought over the upgrading doc from the legacy content, I
introduced some problems. The existing doc lacked a `weight`
specification in the document metadata, leading to some errors in
publishing, and prompting us to set a default weight of 0 in
https://github.com/sensu/sensu-docs/pull/554/.

I think this default weight needs to be revisited, but as a first step
lets set an appropriate weight for the upgrade docs.