### PR TITLE
[reference/handlers] remove "ok" as allowed severity

### DIFF
--- a/docs/0.23/reference/handlers.md
+++ b/docs/0.23/reference/handlers.md
@@ -278,7 +278,7 @@ The following attributes are configured within the `{"handlers": { "HANDLER": {}
 : type
   : Array
 : allowed values
-  : `ok`, `warning`, `critical`, `unknown`
+  : `warning`, `critical`, `unknown`
 : example
   : ~~~ shell
     "severities": ["critical", "unknown"]

--- a/docs/0.24/api/aggregates-api.md
+++ b/docs/0.24/api/aggregates-api.md
@@ -346,7 +346,7 @@ $ curl -s http://localhost:4567/aggregates/elasticsearch/results/critical | jq .
       - **type**: Integer
       - **description**: the maximum age of results to include, in seconds.
 : allowed values
-  : `ok`, `warning`, `critical`, `unknown`
+  : `warning`, `critical`, `unknown`
 : response codes
   : - **Success**: 200 (OK)
     - **Missing**: 404 (Not Found)

--- a/docs/0.24/reference/handlers.md
+++ b/docs/0.24/reference/handlers.md
@@ -279,7 +279,7 @@ The following attributes are configured within the `{"handlers": { "HANDLER": {}
 : type
   : Array
 : allowed values
-  : `ok`, `warning`, `critical`, `unknown`
+  : `warning`, `critical`, `unknown`
 : example
   : ~~~ shell
     "severities": ["critical", "unknown"]

--- a/docs/0.25/api/aggregates-api.md
+++ b/docs/0.25/api/aggregates-api.md
@@ -345,7 +345,7 @@ $ curl -s http://localhost:4567/aggregates/elasticsearch/results/critical | jq .
       - **type**: Integer
       - **description**: the maximum age of results to include, in seconds.
 : allowed values
-  : `ok`, `warning`, `critical`, `unknown`
+  : `warning`, `critical`, `unknown`
 : response codes
   : - **Success**: 200 (OK)
     - **Missing**: 404 (Not Found)

--- a/docs/0.25/reference/handlers.md
+++ b/docs/0.25/reference/handlers.md
@@ -279,7 +279,7 @@ The following attributes are configured within the `{"handlers": { "HANDLER": {}
 : type
   : Array
 : allowed values
-  : `ok`, `warning`, `critical`, `unknown`
+  : `warning`, `critical`, `unknown`
 : example
   : ~~~ shell
     "severities": ["critical", "unknown"]

--- a/docs/0.26/api/aggregates-api.md
+++ b/docs/0.26/api/aggregates-api.md
@@ -346,7 +346,7 @@ $ curl -s http://localhost:4567/aggregates/elasticsearch/results/critical | jq .
       - **type**: Integer
       - **description**: the maximum age of results to include, in seconds.
 : allowed values
-  : `ok`, `warning`, `critical`, `unknown`
+  : `warning`, `critical`, `unknown`
 : response codes
   : - **Success**: 200 (OK)
     - **Missing**: 404 (Not Found)

--- a/docs/0.26/reference/handlers.md
+++ b/docs/0.26/reference/handlers.md
@@ -292,7 +292,7 @@ The following attributes are configured within the `{"handlers": { "HANDLER": {}
 : type
   : Array
 : allowed values
-  : `ok`, `warning`, `critical`, `unknown`
+  : `warning`, `critical`, `unknown`
 : example
   : ~~~ shell
     "severities": ["critical", "unknown"]

--- a/docs/0.27/api/aggregates-api.md
+++ b/docs/0.27/api/aggregates-api.md
@@ -346,7 +346,7 @@ $ curl -s http://localhost:4567/aggregates/elasticsearch/results/critical | jq .
       - **type**: Integer
       - **description**: the maximum age of results to include, in seconds.
 : allowed values
-  : `ok`, `warning`, `critical`, `unknown`
+  : `warning`, `critical`, `unknown`
 : response codes
   : - **Success**: 200 (OK)
     - **Missing**: 404 (Not Found)

--- a/docs/0.27/reference/handlers.md
+++ b/docs/0.27/reference/handlers.md
@@ -292,7 +292,7 @@ The following attributes are configured within the `{"handlers": { "HANDLER": {}
 : type
   : Array
 : allowed values
-  : `ok`, `warning`, `critical`, `unknown`
+  : `warning`, `critical`, `unknown`
 : example
   : ~~~ shell
     "severities": ["critical", "unknown"]

--- a/docs/0.28/api/aggregates-api.md
+++ b/docs/0.28/api/aggregates-api.md
@@ -346,7 +346,7 @@ $ curl -s http://localhost:4567/aggregates/elasticsearch/results/critical | jq .
       - **type**: Integer
       - **description**: the maximum age of results to include, in seconds.
 : allowed values
-  : `ok`, `warning`, `critical`, `unknown`
+  : `warning`, `critical`, `unknown`
 : response codes
   : - **Success**: 200 (OK)
     - **Missing**: 404 (Not Found)

--- a/docs/0.28/reference/handlers.md
+++ b/docs/0.28/reference/handlers.md
@@ -292,7 +292,7 @@ The following attributes are configured within the `{"handlers": { "HANDLER": {}
 : type
   : Array
 : allowed values
-  : `ok`, `warning`, `critical`, `unknown`
+  : `warning`, `critical`, `unknown`
 : example
   : ~~~ shell
     "severities": ["critical", "unknown"]

--- a/docs/0.29/api/aggregates-api.md
+++ b/docs/0.29/api/aggregates-api.md
@@ -346,7 +346,7 @@ $ curl -s http://localhost:4567/aggregates/elasticsearch/results/critical | jq .
       - **type**: Integer
       - **description**: the maximum age of results to include, in seconds.
 : allowed values
-  : `ok`, `warning`, `critical`, `unknown`
+  : `warning`, `critical`, `unknown`
 : response codes
   : - **Success**: 200 (OK)
     - **Missing**: 404 (Not Found)

--- a/docs/0.29/reference/handlers.md
+++ b/docs/0.29/reference/handlers.md
@@ -292,7 +292,7 @@ The following attributes are configured within the `{"handlers": { "HANDLER": {}
 : type
   : Array
 : allowed values
-  : `ok`, `warning`, `critical`, `unknown`
+  : `warning`, `critical`, `unknown`
 : example
   : ~~~ shell
     "severities": ["critical", "unknown"]

--- a/legacy/0.17/handlers.md
+++ b/legacy/0.17/handlers.md
@@ -124,7 +124,7 @@ severities
 : type
   : Array
 : allowed values
-  : `ok`, `warning`, `critical`, `unknown`
+  : `warning`, `critical`, `unknown`
 : example
   : ~~~ shell
     "severities": ["critical", "unknown"]

--- a/legacy/0.18/handlers.md
+++ b/legacy/0.18/handlers.md
@@ -124,7 +124,7 @@ severities
 : type
   : Array
 : allowed values
-  : `ok`, `warning`, `critical`, `unknown`
+  : `warning`, `critical`, `unknown`
 : example
   : ~~~ shell
     "severities": ["critical", "unknown"]

--- a/legacy/0.19/handlers.md
+++ b/legacy/0.19/handlers.md
@@ -124,7 +124,7 @@ severities
 : type
   : Array
 : allowed values
-  : `ok`, `warning`, `critical`, `unknown`
+  : `warning`, `critical`, `unknown`
 : example
   : ~~~ shell
     "severities": ["critical", "unknown"]

--- a/legacy/0.20/handlers.md
+++ b/legacy/0.20/handlers.md
@@ -124,7 +124,7 @@ severities
 : type
   : Array
 : allowed values
-  : `ok`, `warning`, `critical`, `unknown`
+  : `warning`, `critical`, `unknown`
 : example
   : ~~~ shell
     "severities": ["critical", "unknown"]

--- a/legacy/0.21/handlers.md
+++ b/legacy/0.21/handlers.md
@@ -124,7 +124,7 @@ severities
 : type
   : Array
 : allowed values
-  : `ok`, `warning`, `critical`, `unknown`
+  : `warning`, `critical`, `unknown`
 : example
   : ~~~ shell
     "severities": ["critical", "unknown"]

--- a/legacy/0.22/handlers.md
+++ b/legacy/0.22/handlers.md
@@ -124,7 +124,7 @@ severities
 : type
   : Array
 : allowed values
-  : `ok`, `warning`, `critical`, `unknown`
+  : `warning`, `critical`, `unknown`
 : example
   : ~~~ shell
     "severities": ["critical", "unknown"]


### PR DESCRIPTION
As described in sensu/sensu#1677 and #596, adding "ok" to severities 
doesn't have the effect users might expect. In reality any string can be
provided as a value for severities attribute, but only "warning",
"critical" and "unknown" actually have any effect.

Closes #596