### PR TITLE
update filter reference to indicate usage wrt handler sets

### DIFF
--- a/docs/0.23/reference/filters.md
+++ b/docs/0.23/reference/filters.md
@@ -63,6 +63,9 @@ filter analysis flow performs these steps:
 - As soon as a Filter removes an Event (i.e. filters it out), no further
   analysis is performed and the Event Handler will not be executed
 
+_NOTE: Filters specified in a [handler set][14] definition have no effect. Filters
+must be specified in individual handler definitions._
+
 ### Inclusive and Exclusive Filtering
 
 Filters can be _inclusive_ (`"negate": false`) or _exclusive_  (`"negate":
@@ -371,3 +374,4 @@ filter definition is within the `"filters": {}` definition scope.
 [11]: events.html#event-data-specification
 [12]: checks.html#custom-definition-attributes
 [13]: #eval-token-interpolation
+[14]: handlers.html#handler-sets

--- a/docs/0.24/reference/filters.md
+++ b/docs/0.24/reference/filters.md
@@ -64,6 +64,9 @@ filter analysis flow performs these steps:
 - As soon as a Filter removes an Event (i.e. filters it out), no further
   analysis is performed and the Event Handler will not be executed
 
+_NOTE: Filters specified in a [handler set][14] definition have no effect. Filters
+must be specified in individual handler definitions._
+
 ### Inclusive and Exclusive Filtering
 
 Filters can be _inclusive_ (`"negate": false`) or _exclusive_  (`"negate":
@@ -372,3 +375,4 @@ filter definition is within the `"filters": {}` definition scope.
 [11]: events.html#event-data-specification
 [12]: checks.html#custom-attributes
 [13]: #eval-token-interpolation
+[14]: handlers.html#handler-sets

--- a/docs/0.25/reference/filters.md
+++ b/docs/0.25/reference/filters.md
@@ -64,6 +64,9 @@ filter analysis flow performs these steps:
 - As soon as a Filter removes an Event (i.e. filters it out), no further
   analysis is performed and the Event Handler will not be executed
 
+_NOTE: Filters specified in a [handler set][14] definition have no effect. Filters
+must be specified in individual handler definitions._
+
 ### Inclusive and Exclusive Filtering
 
 Filters can be _inclusive_ (`"negate": false`) or _exclusive_  (`"negate":
@@ -372,3 +375,4 @@ filter definition is within the `"filters": {}` definition scope.
 [11]: events.html#event-data-specification
 [12]: checks.html#custom-attributes
 [13]: #eval-token-interpolation
+[14]: handlers.html#handler-sets

--- a/docs/0.26/reference/filters.md
+++ b/docs/0.26/reference/filters.md
@@ -65,6 +65,9 @@ filter analysis flow performs these steps:
 - As soon as a Filter removes an Event (i.e. filters it out), no further
   analysis is performed and the Event Handler will not be executed
 
+_NOTE: Filters specified in a [handler set][16] definition have no effect.
+Filters must be specified in individual handler definitions._
+
 ### Inclusive and Exclusive Filtering
 
 Filters can be _inclusive_ (`"negate": false`) or _exclusive_  (`"negate":
@@ -457,3 +460,4 @@ name][15]).
 [13]: #eval-token-interpolation
 [14]: #when-attributes
 [15]: #filter-naming
+[16]: handlers.html#handler-sets

--- a/docs/0.27/reference/filters.md
+++ b/docs/0.27/reference/filters.md
@@ -65,6 +65,9 @@ filter analysis flow performs these steps:
 - As soon as a Filter removes an Event (i.e. filters it out), no further
   analysis is performed and the Event Handler will not be executed
 
+_NOTE: Filters specified in a [handler set][16] definition have no effect.
+Filters must be specified in individual handler definitions._
+
 ### Inclusive and Exclusive Filtering
 
 Filters can be _inclusive_ (`"negate": false`) or _exclusive_  (`"negate":
@@ -457,3 +460,4 @@ name][15]).
 [13]: #eval-token-interpolation
 [14]: #when-attributes
 [15]: #filter-naming
+[16]: handlers.html#handler-sets

--- a/docs/0.28/reference/filters.md
+++ b/docs/0.28/reference/filters.md
@@ -65,6 +65,9 @@ filter analysis flow performs these steps:
 - As soon as a Filter removes an Event (i.e. filters it out), no further
   analysis is performed and the Event Handler will not be executed
 
+_NOTE: Filters specified in a [handler set][16] definition have no effect. Filters
+must be specified in individual handler definitions._
+
 ### Inclusive and Exclusive Filtering
 
 Filters can be _inclusive_ (`"negate": false`) or _exclusive_  (`"negate":
@@ -457,3 +460,4 @@ name][15]).
 [13]: #eval-token-interpolation
 [14]: #when-attributes
 [15]: #filter-naming
+[16]: handlers.html#handler-sets

--- a/docs/0.29/reference/filters.md
+++ b/docs/0.29/reference/filters.md
@@ -65,6 +65,9 @@ filter analysis flow performs these steps:
 - As soon as a Filter removes an Event (i.e. filters it out), no further
   analysis is performed and the Event Handler will not be executed
 
+_NOTE: Filters specified in a [handler set][16] definition have no effect.
+Filters must be specified in individual handler definitions._
+
 ### Inclusive and Exclusive Filtering
 
 Filters can be _inclusive_ (`"negate": false`) or _exclusive_  (`"negate":
@@ -457,3 +460,4 @@ name][15]).
 [13]: #eval-token-interpolation
 [14]: #when-attributes
 [15]: #filter-naming
+[16]: handlers.html#handler-sets

--- a/docs/1.0/reference/filters.md
+++ b/docs/1.0/reference/filters.md
@@ -65,6 +65,9 @@ filter analysis flow performs these steps:
 - As soon as a Filter removes an Event (i.e. filters it out), no further
   analysis is performed and the Event Handler will not be executed
 
+_NOTE: Filters specified in a [handler set][16] definition have no effect.
+Filters must be specified in individual handler definitions._
+
 ### Inclusive and Exclusive Filtering
 
 Filters can be _inclusive_ (`"negate": false`) or _exclusive_  (`"negate":
@@ -457,3 +460,4 @@ name][15]).
 [13]: #eval-token-interpolation
 [14]: #when-attributes
 [15]: #filter-naming
+[16]: handlers.html#handler-sets


### PR DESCRIPTION
Per user reports like https://github.com/sensu/sensu/issues/1691 and https://groups.google.com/d/msg/sensu-users/GayX15QLTX0/t9qVpwuNAwAJ, it seems that the current documentation around handler sets isn't sufficient to help folks understand that filters can't be applied in a handler set definition. This change seeks to make this detail more apparent by documenting it in the filter reference.