### PR TITLE
Fix incorrect reconnect_on_error default value in redis reference doc

### DIFF
--- a/docs/0.23/reference/redis.md
+++ b/docs/0.23/reference/redis.md
@@ -212,10 +212,10 @@ The Redis definition uses the `"redis": {}` definition scope.
 : type
   : Boolean
 : default
-  : `false`
+  : `true`
 : example
   : ~~~ shell
-    "reconnect_on_error": true
+    "reconnect_on_error": false
     ~~~
 
 `master`

--- a/docs/0.24/reference/redis.md
+++ b/docs/0.24/reference/redis.md
@@ -213,10 +213,10 @@ The Redis definition uses the `"redis": {}` definition scope.
 : type
   : Boolean
 : default
-  : `false`
+  : `true`
 : example
   : ~~~ shell
-    "reconnect_on_error": true
+    "reconnect_on_error": false
     ~~~
 
 `master`

--- a/docs/0.25/reference/redis.md
+++ b/docs/0.25/reference/redis.md
@@ -213,10 +213,10 @@ The Redis definition uses the `"redis": {}` definition scope.
 : type
   : Boolean
 : default
-  : `false`
+  : `true`
 : example
   : ~~~ shell
-    "reconnect_on_error": true
+    "reconnect_on_error": false
     ~~~
 
 `master`

--- a/docs/0.26/reference/redis.md
+++ b/docs/0.26/reference/redis.md
@@ -213,10 +213,10 @@ The Redis definition uses the `"redis": {}` definition scope.
 : type
   : Boolean
 : default
-  : `false`
+  : `true`
 : example
   : ~~~ shell
-    "reconnect_on_error": true
+    "reconnect_on_error": false
     ~~~
 
 `master`

--- a/docs/0.27/reference/redis.md
+++ b/docs/0.27/reference/redis.md
@@ -222,10 +222,10 @@ The Redis definition uses the `"redis": {}` definition scope.
 : type
   : Boolean
 : default
-  : `false`
+  : `true`
 : example
   : ~~~ shell
-    "reconnect_on_error": true
+    "reconnect_on_error": false
     ~~~
 
 `master`

--- a/docs/0.28/reference/redis.md
+++ b/docs/0.28/reference/redis.md
@@ -222,10 +222,10 @@ The Redis definition uses the `"redis": {}` definition scope.
 : type
   : Boolean
 : default
-  : `false`
+  : `true`
 : example
   : ~~~ shell
-    "reconnect_on_error": true
+    "reconnect_on_error": false
     ~~~
 
 `master`

--- a/docs/0.29/reference/redis.md
+++ b/docs/0.29/reference/redis.md
@@ -222,10 +222,10 @@ The Redis definition uses the `"redis": {}` definition scope.
 : type
   : Boolean
 : default
-  : `false`
+  : `true`
 : example
   : ~~~ shell
-    "reconnect_on_error": true
+    "reconnect_on_error": false
     ~~~
 
 `master`


### PR DESCRIPTION
Per the source code, redis reconnect_on_error defaults to `true` since
sensu-redis v0.1.7, circa Sensu 0.22.0.