### PR TITLE
Fix link to filters reference

### DIFF
--- a/docs/0.29/guides/getting-started/intro-to-filters.md
+++ b/docs/0.29/guides/getting-started/intro-to-filters.md
@@ -147,4 +147,4 @@ once per hour.
 }
 ~~~
 
-[1]:  ../reference/filters.html
+[1]:  ../../reference/filters.html


### PR DESCRIPTION
it's up one more directory from current path. 

Confirmed URL is: https://sensuapp.org/docs/0.29/reference/filters.html when current location is: https://sensuapp.org/docs/0.29/guides/getting-started/intro-to-filters.html, which maths to be 2 🙌 