### PR TITLE
Update RedHat and Debian platform pages to describe supported versions

### DIFF
--- a/docs/0.27/platforms/sensu-on-rhel-centos.md
+++ b/docs/0.27/platforms/sensu-on-rhel-centos.md
@@ -46,11 +46,22 @@ package installs several processes including `sensu-server`, `sensu-api`, and
 
 ### Install Sensu using YUM (recommended) {#install-sensu-core-repository}
 
+Sensu packages for Red Hat target currently supported versions of Red Hat
+Enterprise Linux and their Centos equivalents. These packages are generally
+expected to be compatible with Red Hat derivatives like SuSE, Amazon or
+Scientific Linux, but packages are not tested on these platforms.
+
+The following instructions describe configuring package repository definitions
+using [Yum variables][14] as components of the baseurl. On Red Hat derivative
+platforms the value of the `$releasever` variable will not typically align with
+the RHEL release versions (e.g. `6` or `7`) advertised in the Sensu Yum
+repository. Please use `6` or `7` in lieu of `$releasever` on RHEL derivatives,
+depending on whether they use sysv init or systemd, respectively.
+
 _NOTE: As of Sensu version 0.27, the yum repository URL has changed to
 include the `$releasever` variable. To install or upgrade to the
 latest version of Sensu, please ensure you have updated existing
 repository configurations._
-
 
 1. Create the YUM repository configuration file for the Sensu Core repository at
    `/etc/yum.repos.d/sensu.repo`:
@@ -459,3 +470,4 @@ script must be used, e.g. `sudo /etc/init.d/sensu-client start`_
 [11]: #example-transport-configuration
 [12]: #example-client-configuration
 [13]: #example-data-store-configuration
+[14]: https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/6/html/Deployment_Guide/sec-Using_Yum_Variables.html

--- a/docs/0.27/platforms/sensu-on-ubuntu-debian.md
+++ b/docs/0.27/platforms/sensu-on-ubuntu-debian.md
@@ -44,6 +44,15 @@ installer package (i.e. a .deb file), which is available for download from the
 Sensu Core package installs several processes including `sensu-server`,
 `sensu-api`, and `sensu-client`.
 
+Sensu packages for Debian target current [`stable` and `oldstable`
+releases][15].
+
+Sensu packages for Ubuntu target current [Long Term Support (LTS) releases][16].
+
+If you wish to install Sensu packages on newer Debian or Ubuntu releases, please
+try installing a package built for the most recent Debian `stable` or
+Ubuntu LTS release.
+
 ### Install Sensu using APT (recommended) {#install-sensu-core-repository}
 
 _NOTE: As of Sensu version 0.27, apt repository configuration has
@@ -469,3 +478,5 @@ To manually start and stop the Sensu services, use the following commands:
 [12]: #example-transport-configuration
 [13]: #example-client-configuration
 [14]: #example-data-store-configuration
+[15]: https://wiki.debian.org/DebianReleases
+[16]: https://wiki.ubuntu.com/LTS

--- a/docs/0.28/platforms/sensu-on-rhel-centos.md
+++ b/docs/0.28/platforms/sensu-on-rhel-centos.md
@@ -46,11 +46,22 @@ package installs several processes including `sensu-server`, `sensu-api`, and
 
 ### Install Sensu using YUM (recommended) {#install-sensu-core-repository}
 
-_NOTE: As of Sensu version 0.28, the yum repository URL has changed to
+Sensu packages for Red Hat target currently supported versions of Red Hat
+Enterprise Linux and their Centos equivalents. These packages are generally
+expected to be compatible with Red Hat derivatives like SuSE, Amazon or
+Scientific Linux, but packages are not tested on these platforms.
+
+The following instructions describe configuring package repository definitions
+using [Yum variables][14] as components of the baseurl. On Red Hat derivative
+platforms the value of the `$releasever` variable will not typically align with
+the RHEL release versions (e.g. `6` or `7`) advertised in the Sensu Yum
+repository. Please use `6` or `7` in lieu of `$releasever` on RHEL derivatives,
+depending on whether they use sysv init or systemd, respectively.
+
+_NOTE: As of Sensu version 0.27, the yum repository URL has changed to
 include the `$releasever` variable. To install or upgrade to the
 latest version of Sensu, please ensure you have updated existing
 repository configurations._
-
 
 1. Create the YUM repository configuration file for the Sensu Core repository at
    `/etc/yum.repos.d/sensu.repo`:
@@ -459,3 +470,4 @@ script must be used, e.g. `sudo /etc/init.d/sensu-client start`_
 [11]: #example-transport-configuration
 [12]: #example-client-configuration
 [13]: #example-data-store-configuration
+[14]: https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/6/html/Deployment_Guide/sec-Using_Yum_Variables.html

--- a/docs/0.28/platforms/sensu-on-ubuntu-debian.md
+++ b/docs/0.28/platforms/sensu-on-ubuntu-debian.md
@@ -44,9 +44,18 @@ installer package (i.e. a .deb file), which is available for download from the
 Sensu Core package installs several processes including `sensu-server`,
 `sensu-api`, and `sensu-client`.
 
+Sensu packages for Debian target current [`stable` and `oldstable`
+releases][15].
+
+Sensu packages for Ubuntu target current [Long Term Support (LTS) releases][16].
+
+If you wish to install Sensu packages on newer Debian or Ubuntu releases, please
+try installing a package built for the most recent Debian `stable` or
+Ubuntu LTS release.
+
 ### Install Sensu using APT (recommended) {#install-sensu-core-repository}
 
-_NOTE: As of Sensu version 0.28, apt repository configuration has
+_NOTE: As of Sensu version 0.27, apt repository configuration has
 changed to include the "codename" of the Ubuntu/Debian release. To
 install or upgrade to the latest version of Sensu, please ensure you
 have updated existing repository configurations._
@@ -469,3 +478,5 @@ To manually start and stop the Sensu services, use the following commands:
 [12]: #example-transport-configuration
 [13]: #example-client-configuration
 [14]: #example-data-store-configuration
+[15]: https://wiki.debian.org/DebianReleases
+[16]: https://wiki.ubuntu.com/LTS

--- a/docs/0.29/platforms/sensu-on-rhel-centos.md
+++ b/docs/0.29/platforms/sensu-on-rhel-centos.md
@@ -46,11 +46,22 @@ package installs several processes including `sensu-server`, `sensu-api`, and
 
 ### Install Sensu using YUM (recommended) {#install-sensu-core-repository}
 
-_NOTE: As of Sensu version 0.29, the yum repository URL has changed to
+Sensu packages for Red Hat target currently supported versions of Red Hat
+Enterprise Linux and their Centos equivalents. These packages are generally
+expected to be compatible with Red Hat derivatives like SuSE, Amazon or
+Scientific Linux, but packages are not tested on these platforms.
+
+The following instructions describe configuring package repository definitions
+using [Yum variables][14] as components of the baseurl. On Red Hat derivative
+platforms the value of the `$releasever` variable will not typically align with
+the RHEL release versions (e.g. `6` or `7`) advertised in the Sensu Yum
+repository. Please use `6` or `7` in lieu of `$releasever` on RHEL derivatives,
+depending on whether they use sysv init or systemd, respectively.
+
+_NOTE: As of Sensu version 0.27, the yum repository URL has changed to
 include the `$releasever` variable. To install or upgrade to the
 latest version of Sensu, please ensure you have updated existing
 repository configurations._
-
 
 1. Create the YUM repository configuration file for the Sensu Core repository at
    `/etc/yum.repos.d/sensu.repo`:
@@ -459,3 +470,4 @@ script must be used, e.g. `sudo /etc/init.d/sensu-client start`_
 [11]: #example-transport-configuration
 [12]: #example-client-configuration
 [13]: #example-data-store-configuration
+[14]: https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/6/html/Deployment_Guide/sec-Using_Yum_Variables.html

--- a/docs/0.29/platforms/sensu-on-ubuntu-debian.md
+++ b/docs/0.29/platforms/sensu-on-ubuntu-debian.md
@@ -44,9 +44,18 @@ installer package (i.e. a .deb file), which is available for download from the
 Sensu Core package installs several processes including `sensu-server`,
 `sensu-api`, and `sensu-client`.
 
+Sensu packages for Debian target current [`stable` and `oldstable`
+releases][15].
+
+Sensu packages for Ubuntu target current [Long Term Support (LTS) releases][16].
+
+If you wish to install Sensu packages on newer Debian or Ubuntu releases, please
+try installing a package built for the most recent Debian `stable` or
+Ubuntu LTS release.
+
 ### Install Sensu using APT (recommended) {#install-sensu-core-repository}
 
-_NOTE: As of Sensu version 0.29, apt repository configuration has
+_NOTE: As of Sensu version 0.27, apt repository configuration has
 changed to include the "codename" of the Ubuntu/Debian release. To
 install or upgrade to the latest version of Sensu, please ensure you
 have updated existing repository configurations._
@@ -469,3 +478,5 @@ To manually start and stop the Sensu services, use the following commands:
 [12]: #example-transport-configuration
 [13]: #example-client-configuration
 [14]: #example-data-store-configuration
+[15]: https://wiki.debian.org/DebianReleases
+[16]: https://wiki.ubuntu.com/LTS

--- a/docs/1.0/platforms/sensu-on-rhel-centos.md
+++ b/docs/1.0/platforms/sensu-on-rhel-centos.md
@@ -46,11 +46,22 @@ package installs several processes including `sensu-server`, `sensu-api`, and
 
 ### Install Sensu using YUM (recommended) {#install-sensu-core-repository}
 
+Sensu packages for Red Hat target currently supported versions of Red Hat
+Enterprise Linux and their Centos equivalents. These packages are generally
+expected to be compatible with Red Hat derivatives like SuSE, Amazon or
+Scientific Linux, but packages are not tested on these platforms.
+
+The following instructions describe configuring package repository definitions
+using [Yum variables][14] as components of the baseurl. On Red Hat derivative
+platforms the value of the `$releasever` variable will not typically align with
+the RHEL release versions (e.g. `6` or `7`) advertised in the Sensu Yum
+repository. Please use `6` or `7` in lieu of `$releasever` on RHEL derivatives,
+depending on whether they use sysv init or systemd, respectively.
+
 _NOTE: As of Sensu version 0.27, the yum repository URL has changed to
 include the `$releasever` variable. To install or upgrade to the
 latest version of Sensu, please ensure you have updated existing
 repository configurations._
-
 
 1. Create the YUM repository configuration file for the Sensu Core repository at
    `/etc/yum.repos.d/sensu.repo`:
@@ -459,3 +470,4 @@ script must be used, e.g. `sudo /etc/init.d/sensu-client start`_
 [11]: #example-transport-configuration
 [12]: #example-client-configuration
 [13]: #example-data-store-configuration
+[14]: https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/6/html/Deployment_Guide/sec-Using_Yum_Variables.html

--- a/docs/1.0/platforms/sensu-on-ubuntu-debian.md
+++ b/docs/1.0/platforms/sensu-on-ubuntu-debian.md
@@ -44,6 +44,15 @@ installer package (i.e. a .deb file), which is available for download from the
 Sensu Core package installs several processes including `sensu-server`,
 `sensu-api`, and `sensu-client`.
 
+Sensu packages for Debian target current [`stable` and `oldstable`
+releases][15].
+
+Sensu packages for Ubuntu target current [Long Term Support (LTS) releases][16].
+
+If you wish to install Sensu packages on newer Debian or Ubuntu releases, please
+try installing a package built for the most recent Debian `stable` or
+Ubuntu LTS release.
+
 ### Install Sensu using APT (recommended) {#install-sensu-core-repository}
 
 _NOTE: As of Sensu version 0.27, apt repository configuration has
@@ -469,3 +478,5 @@ To manually start and stop the Sensu services, use the following commands:
 [12]: #example-transport-configuration
 [13]: #example-client-configuration
 [14]: #example-data-store-configuration
+[15]: https://wiki.debian.org/DebianReleases
+[16]: https://wiki.ubuntu.com/LTS


### PR DESCRIPTION
We document the build matrix for Sensu Core packages in the readme for sensu-omnibus project but this information isn't visible to folks installing via the instructions on our website. As a result, we receive reports similar to https://github.com/sensu/sensu/issues/1707 asking where packages can be obtained for platform versions we don't really aim to specifically support.

The intent of these changes is to update platform documentation to reduce confusion by indicating which versions of these platforms are supported.

Once we have agreed on wording for the 1.0 docs I will implement the changes in older versions of the docs as well.