### PR TITLE
Document CONFIG_DIR env var renamed to CONFD_DIR

### DIFF
--- a/docs/0.27/installation/upgrading.md
+++ b/docs/0.27/installation/upgrading.md
@@ -1,5 +1,5 @@
 ---
-version: 0.28
+version: 0.27
 category: "Upgrading Guide"
 title: "Upgrading Sensu"
 weight: 8
@@ -36,6 +36,20 @@ Stopping services prior to upgrading from a Sensu version < `0.27`
 helps to avoid service management errors related to the transition
 from sysv init scripts to systemd unit files on platforms like Debian
 8, Ubuntu 16.04 and Centos 7 or newer.
+
+### Update environment variables
+
+As of Sensu 0.27 and later, the `CONFIG_DIR` environment variable has been
+renamed to `CONFD_DIR`.
+
+If you have customized your Sensu installation using this environment variable,
+you may need to update one or more of the following files to reflect the change:
+
+  *  `/etc/default/sensu`
+  *  `/etc/default/sensu-server`
+  *  `/etc/default/sensu-client`
+  *  `/etc/default/sensu-api`
+  *  `/etc/default/sensu-enterprise`
 
 ## Upgrading from Sensu < 0.17
 

--- a/docs/0.27/overview/changelog.md
+++ b/docs/0.27/overview/changelog.md
@@ -89,6 +89,14 @@ This release includes potentially breaking, backwards-incompatible changes:
 	upgraded from winsw 1.16. This version includes a number of changes
 	which should help to address issues around orphaned processes.
 
+- **CHANGED**: The CONFIG_DIR environment variable has been renamed to
+            CONFD_DIR. This environment varible is used to specify the
+            directory path where Sensu processes will load any JSON
+            config files for deep merging. If you are using
+            /etc/default/sensu to specify a custom value for
+            `CONFIG_DIR`, please update it to the new `CONFD_DIR`
+            variable name.
+
 ### CHANGES {#core-v0-27-0-changes}
 
 - **NEW**: Added a Sensu client HTTP socket for check result input and

--- a/docs/0.27/reference/configuration.md
+++ b/docs/0.27/reference/configuration.md
@@ -324,7 +324,7 @@ platform.
     CONFIG_FILE=/etc/sensu/config.json
     ~~~
 
-`CONFIG_DIR`
+`CONFD_DIR`
 : description
   : The configuration snippet directory path.
 : required
@@ -333,7 +333,7 @@ platform.
   : `/etc/sensu/conf.d`
 : example
   : ~~~ shell
-    CONFIG_DIR=/etc/sensu/conf.d
+    CONFD_DIR=/etc/sensu/conf.d
     ~~~
 
 `EXTENSION_DIR`

--- a/docs/0.28/installation/upgrading.md
+++ b/docs/0.28/installation/upgrading.md
@@ -37,6 +37,20 @@ helps to avoid service management errors related to the transition
 from sysv init scripts to systemd unit files on platforms like Debian
 8, Ubuntu 16.04 and Centos 7 or newer.
 
+### Update environment variables
+
+As of Sensu 0.27 and later, the `CONFIG_DIR` environment variable has been
+renamed to `CONFD_DIR`.
+
+If you have customized your Sensu installation using this environment variable,
+you may need to update one or more of the following files to reflect the change:
+
+  *  `/etc/default/sensu`
+  *  `/etc/default/sensu-server`
+  *  `/etc/default/sensu-client`
+  *  `/etc/default/sensu-api`
+  *  `/etc/default/sensu-enterprise`
+
 ## Upgrading from Sensu < 0.17
 
 The following documentation provides steps necessary when upgrading

--- a/docs/0.28/reference/configuration.md
+++ b/docs/0.28/reference/configuration.md
@@ -324,7 +324,7 @@ platform.
     CONFIG_FILE=/etc/sensu/config.json
     ~~~
 
-`CONFIG_DIR`
+`CONFD_DIR`
 : description
   : The configuration snippet directory path.
 : required
@@ -333,7 +333,7 @@ platform.
   : `/etc/sensu/conf.d`
 : example
   : ~~~ shell
-    CONFIG_DIR=/etc/sensu/conf.d
+    CONFD_DIR=/etc/sensu/conf.d
     ~~~
 
 `EXTENSION_DIR`

--- a/docs/0.29/installation/upgrading.md
+++ b/docs/0.29/installation/upgrading.md
@@ -42,6 +42,20 @@ helps to avoid service management errors related to the transition
 from sysv init scripts to systemd unit files on platforms like Debian
 8, Ubuntu 16.04 and Centos 7 or newer.
 
+### Update environment variables
+
+As of Sensu 0.27 and later, the `CONFIG_DIR` environment variable has been
+renamed to `CONFD_DIR`.
+
+If you have customized your Sensu installation using this environment variable,
+you may need to update one or more of the following files to reflect the change:
+
+  *  `/etc/default/sensu`
+  *  `/etc/default/sensu-server`
+  *  `/etc/default/sensu-client`
+  *  `/etc/default/sensu-api`
+  *  `/etc/default/sensu-enterprise`
+
 ## Upgrading from Sensu < 0.17
 
 The following documentation provides steps necessary when upgrading

--- a/docs/0.29/reference/configuration.md
+++ b/docs/0.29/reference/configuration.md
@@ -324,7 +324,7 @@ platform.
     CONFIG_FILE=/etc/sensu/config.json
     ~~~
 
-`CONFIG_DIR`
+`CONFD_DIR`
 : description
   : The configuration snippet directory path.
 : required
@@ -333,7 +333,7 @@ platform.
   : `/etc/sensu/conf.d`
 : example
   : ~~~ shell
-    CONFIG_DIR=/etc/sensu/conf.d
+    CONFD_DIR=/etc/sensu/conf.d
     ~~~
 
 `EXTENSION_DIR`

--- a/docs/1.0/installation/upgrading.md
+++ b/docs/1.0/installation/upgrading.md
@@ -42,6 +42,20 @@ helps to avoid service management errors related to the transition
 from sysv init scripts to systemd unit files on platforms like Debian
 8, Ubuntu 16.04 and Centos 7 or newer.
 
+### Update environment variables
+
+As of Sensu 0.27 and later, the `CONFIG_DIR` environment variable has been
+renamed to `CONFD_DIR`.
+
+If you have customized your Sensu installation using this environment variable,
+you may need to update one or more of the following files to reflect the change:
+
+  *  `/etc/default/sensu`
+  *  `/etc/default/sensu-server`
+  *  `/etc/default/sensu-client`
+  *  `/etc/default/sensu-api`
+  *  `/etc/default/sensu-enterprise`
+
 ## Upgrading from Sensu < 0.17
 
 The following documentation provides steps necessary when upgrading

--- a/docs/1.0/reference/configuration.md
+++ b/docs/1.0/reference/configuration.md
@@ -324,7 +324,7 @@ platform.
     CONFIG_FILE=/etc/sensu/config.json
     ~~~
 
-`CONFIG_DIR`
+`CONFD_DIR`
 : description
   : The configuration snippet directory path.
 : required
@@ -333,7 +333,7 @@ platform.
   : `/etc/sensu/conf.d`
 : example
   : ~~~ shell
-    CONFIG_DIR=/etc/sensu/conf.d
+    CONFD_DIR=/etc/sensu/conf.d
     ~~~
 
 `EXTENSION_DIR`


### PR DESCRIPTION
This change was introduced in 0.27 but not mentioned in the changelog nor the configuration reference documentation. 😮 