### PR TITLE
remove "recommended" parenthetical from ubuntu platform links

### DIFF
--- a/docs/0.27/installation/install-rabbitmq.md
+++ b/docs/0.27/installation/install-rabbitmq.md
@@ -19,7 +19,7 @@ using RabbitMQ as the Sensu Transport, all Sensu services require access to the
 same instance (or cluster) of RabbitMQ to function. **All Sensu users are
 encouraged to install and run RabbitMQ on one of the following supported platforms:**
 
-- [Install RabbitMQ on Ubuntu/Debian](install-rabbitmq-on-ubuntu-debian.html) (recommended)
+- [Install RabbitMQ on Ubuntu/Debian](install-rabbitmq-on-ubuntu-debian.html)
 - [Install RabbitMQ on RHEL/CentOS](install-rabbitmq-on-rhel-centos.html)
 
 _NOTE: please refer to the [Installation Prerequisites documentation][5]

--- a/docs/0.27/installation/install-redis.md
+++ b/docs/0.27/installation/install-redis.md
@@ -19,7 +19,7 @@ and run Redis on almost any modern operating system, **all Sensu users are
 encouraged to install and run Redis on one of the following _supported_
 platforms**:
 
-- [Install Redis on Ubuntu/Debian](install-redis-on-ubuntu-debian.html) (recommended)
+- [Install Redis on Ubuntu/Debian](install-redis-on-ubuntu-debian.html)
 - [Install Redis on RHEL/CentOS](install-redis-on-rhel-centos.html)
 
 Amazon Web Services [ElastiCache][5] with Redis 2.8.x may be used to

--- a/docs/0.27/overview/platforms.md
+++ b/docs/0.27/overview/platforms.md
@@ -34,7 +34,7 @@ running the `sensu-server` and `sensu-api` processes._
 
 ### Sensu Server & API
 
-- [Ubuntu/Debian](../platforms/sensu-on-ubuntu-debian.html#sensu-core) (recommended)
+- [Ubuntu/Debian](../platforms/sensu-on-ubuntu-debian.html#sensu-core)
 - [RHEL/CentOS](../platforms/sensu-on-rhel-centos.html#sensu-core)
 
 ### Sensu Client
@@ -57,7 +57,7 @@ which provides [added-value][7] replacements for the Sensu Core server
 
 ### Sensu Enterprise Server & API
 
-- [Ubuntu/Debian](sensu-on-ubuntu-debian#sensu-enterprise) (recommended)
+- [Ubuntu/Debian](sensu-on-ubuntu-debian#sensu-enterprise)
 - [RHEL/CentOS](sensu-on-rhel-centos#sensu-enterprise)
 
 ### Sensu Enterprise Client

--- a/docs/0.28/installation/install-rabbitmq.md
+++ b/docs/0.28/installation/install-rabbitmq.md
@@ -19,7 +19,7 @@ using RabbitMQ as the Sensu Transport, all Sensu services require access to the
 same instance (or cluster) of RabbitMQ to function. **All Sensu users are
 encouraged to install and run RabbitMQ on one of the following supported platforms:**
 
-- [Install RabbitMQ on Ubuntu/Debian](install-rabbitmq-on-ubuntu-debian.html) (recommended)
+- [Install RabbitMQ on Ubuntu/Debian](install-rabbitmq-on-ubuntu-debian.html)
 - [Install RabbitMQ on RHEL/CentOS](install-rabbitmq-on-rhel-centos.html)
 
 _NOTE: please refer to the [Installation Prerequisites documentation][5]

--- a/docs/0.28/installation/install-redis.md
+++ b/docs/0.28/installation/install-redis.md
@@ -19,7 +19,7 @@ and run Redis on almost any modern operating system, **all Sensu users are
 encouraged to install and run Redis on one of the following _supported_
 platforms**:
 
-- [Install Redis on Ubuntu/Debian](install-redis-on-ubuntu-debian.html) (recommended)
+- [Install Redis on Ubuntu/Debian](install-redis-on-ubuntu-debian.html)
 - [Install Redis on RHEL/CentOS](install-redis-on-rhel-centos.html)
 
 Amazon Web Services [ElastiCache][5] with Redis 2.8.x may be used to

--- a/docs/0.28/overview/platforms.md
+++ b/docs/0.28/overview/platforms.md
@@ -34,7 +34,7 @@ running the `sensu-server` and `sensu-api` processes._
 
 ### Sensu Server & API
 
-- [Ubuntu/Debian](../platforms/sensu-on-ubuntu-debian.html#sensu-core) (recommended)
+- [Ubuntu/Debian](../platforms/sensu-on-ubuntu-debian.html#sensu-core)
 - [RHEL/CentOS](../platforms/sensu-on-rhel-centos.html#sensu-core)
 
 ### Sensu Client
@@ -57,7 +57,7 @@ which provides [added-value][7] replacements for the Sensu Core server
 
 ### Sensu Enterprise Server & API
 
-- [Ubuntu/Debian](sensu-on-ubuntu-debian#sensu-enterprise) (recommended)
+- [Ubuntu/Debian](sensu-on-ubuntu-debian#sensu-enterprise)
 - [RHEL/CentOS](sensu-on-rhel-centos#sensu-enterprise)
 
 ### Sensu Enterprise Client

--- a/docs/0.29/installation/install-rabbitmq.md
+++ b/docs/0.29/installation/install-rabbitmq.md
@@ -19,7 +19,7 @@ using RabbitMQ as the Sensu Transport, all Sensu services require access to the
 same instance (or cluster) of RabbitMQ to function. **All Sensu users are
 encouraged to install and run RabbitMQ on one of the following supported platforms:**
 
-- [Install RabbitMQ on Ubuntu/Debian](install-rabbitmq-on-ubuntu-debian.html) (recommended)
+- [Install RabbitMQ on Ubuntu/Debian](install-rabbitmq-on-ubuntu-debian.html)
 - [Install RabbitMQ on RHEL/CentOS](install-rabbitmq-on-rhel-centos.html)
 
 _NOTE: please refer to the [Installation Prerequisites documentation][5]

--- a/docs/0.29/installation/install-redis.md
+++ b/docs/0.29/installation/install-redis.md
@@ -19,7 +19,7 @@ and run Redis on almost any modern operating system, **all Sensu users are
 encouraged to install and run Redis on one of the following _supported_
 platforms**:
 
-- [Install Redis on Ubuntu/Debian](install-redis-on-ubuntu-debian.html) (recommended)
+- [Install Redis on Ubuntu/Debian](install-redis-on-ubuntu-debian.html)
 - [Install Redis on RHEL/CentOS](install-redis-on-rhel-centos.html)
 
 Amazon Web Services [ElastiCache][5] with Redis 2.8.x may be used to

--- a/docs/0.29/overview/platforms.md
+++ b/docs/0.29/overview/platforms.md
@@ -34,7 +34,7 @@ running the `sensu-server` and `sensu-api` processes._
 
 ### Sensu Server & API
 
-- [Ubuntu/Debian](../platforms/sensu-on-ubuntu-debian.html#sensu-core) (recommended)
+- [Ubuntu/Debian](../platforms/sensu-on-ubuntu-debian.html#sensu-core)
 - [RHEL/CentOS](../platforms/sensu-on-rhel-centos.html#sensu-core)
 
 ### Sensu Client
@@ -57,7 +57,7 @@ which provides [added-value][7] replacements for the Sensu Core server
 
 ### Sensu Enterprise Server & API
 
-- [Ubuntu/Debian](sensu-on-ubuntu-debian#sensu-enterprise) (recommended)
+- [Ubuntu/Debian](sensu-on-ubuntu-debian#sensu-enterprise)
 - [RHEL/CentOS](sensu-on-rhel-centos#sensu-enterprise)
 
 ### Sensu Enterprise Client

--- a/docs/1.0/installation/install-rabbitmq.md
+++ b/docs/1.0/installation/install-rabbitmq.md
@@ -19,7 +19,7 @@ using RabbitMQ as the Sensu Transport, all Sensu services require access to the
 same instance (or cluster) of RabbitMQ to function. **All Sensu users are
 encouraged to install and run RabbitMQ on one of the following supported platforms:**
 
-- [Install RabbitMQ on Ubuntu/Debian](install-rabbitmq-on-ubuntu-debian.html) (recommended)
+- [Install RabbitMQ on Ubuntu/Debian](install-rabbitmq-on-ubuntu-debian.html)
 - [Install RabbitMQ on RHEL/CentOS](install-rabbitmq-on-rhel-centos.html)
 
 _NOTE: please refer to the [Installation Prerequisites documentation][5]

--- a/docs/1.0/installation/install-redis.md
+++ b/docs/1.0/installation/install-redis.md
@@ -19,7 +19,7 @@ and run Redis on almost any modern operating system, **all Sensu users are
 encouraged to install and run Redis on one of the following _supported_
 platforms**:
 
-- [Install Redis on Ubuntu/Debian](install-redis-on-ubuntu-debian.html) (recommended)
+- [Install Redis on Ubuntu/Debian](install-redis-on-ubuntu-debian.html)
 - [Install Redis on RHEL/CentOS](install-redis-on-rhel-centos.html)
 
 Amazon Web Services [ElastiCache][5] with Redis 2.8.x may be used to

--- a/docs/1.0/overview/platforms.md
+++ b/docs/1.0/overview/platforms.md
@@ -34,7 +34,7 @@ running the `sensu-server` and `sensu-api` processes._
 
 ### Sensu Server & API
 
-- [Ubuntu/Debian](../platforms/sensu-on-ubuntu-debian.html#sensu-core) (recommended)
+- [Ubuntu/Debian](../platforms/sensu-on-ubuntu-debian.html#sensu-core)
 - [RHEL/CentOS](../platforms/sensu-on-rhel-centos.html#sensu-core)
 
 ### Sensu Client
@@ -57,7 +57,7 @@ which provides [added-value][7] replacements for the Sensu Core server
 
 ### Sensu Enterprise Server & API
 
-- [Ubuntu/Debian](sensu-on-ubuntu-debian#sensu-enterprise) (recommended)
+- [Ubuntu/Debian](sensu-on-ubuntu-debian#sensu-enterprise)
 - [RHEL/CentOS](sensu-on-rhel-centos#sensu-enterprise)
 
 ### Sensu Enterprise Client


### PR DESCRIPTION
I'm not aware that there's a reason for us to recommend Debian/Ubuntu
over RedHat/Centos these days.