### PR TITLE
update the doc to be more clear that redact config is override and not merge.

### DIFF
--- a/docs/0.23/reference/clients.md
+++ b/docs/0.23/reference/clients.md
@@ -415,7 +415,7 @@ The client definition uses the `{ "client": {} }` [configuration scope][24].
 `redact`
 : description
   : Client definition attributes to redact (values) when logging and sending
-    client keepalives.
+    client keepalives. When configuring this array, the default values will be overwritten, requiring them to be re-added to your array.
 : required
   : false
 : type

--- a/docs/0.24/reference/clients.md
+++ b/docs/0.24/reference/clients.md
@@ -444,7 +444,7 @@ The client definition uses the `{ "client": {} }` [configuration scope][24].
 `redact`
 : description
   : Client definition attributes to redact (values) when logging and sending
-    client keepalives.
+    client keepalives. When configuring this array, the default values will be overwritten, requiring them to be re-added to your array.
 : required
   : false
 : type

--- a/docs/0.25/reference/clients.md
+++ b/docs/0.25/reference/clients.md
@@ -445,7 +445,7 @@ The client definition uses the `{ "client": {} }` [configuration scope][24].
 `redact`
 : description
   : Client definition attributes to redact (values) when logging and sending
-    client keepalives.
+    client keepalives. When configuring this array, the default values will be overwritten, requiring them to be re-added to your array.
 : required
   : false
 : type

--- a/docs/0.26/reference/clients.md
+++ b/docs/0.26/reference/clients.md
@@ -463,7 +463,7 @@ The client definition uses the `{ "client": {} }` [configuration scope][24].
 `redact`
 : description
   : Client definition attributes to redact (values) when logging and sending
-    client keepalives.
+    client keepalives. When configuring this array, the default values will be overwritten, requiring them to be re-added to your array.
 : required
   : false
 : type

--- a/docs/0.27/reference/clients.md
+++ b/docs/0.27/reference/clients.md
@@ -512,7 +512,7 @@ The client definition uses the `{ "client": {} }` [configuration scope][24].
 `redact`
 : description
   : Client definition attributes to redact (values) when logging and sending
-    client keepalives.
+    client keepalives. When configuring this array, the default values will be overwritten, requiring them to be re-added to your array.
 : required
   : false
 : type

--- a/docs/0.28/reference/clients.md
+++ b/docs/0.28/reference/clients.md
@@ -512,7 +512,7 @@ The client definition uses the `{ "client": {} }` [configuration scope][24].
 `redact`
 : description
   : Client definition attributes to redact (values) when logging and sending
-    client keepalives.
+    client keepalives. When configuring this array, the default values will be overwritten, requiring them to be re-added to your array.
 : required
   : false
 : type

--- a/docs/0.29/reference/clients.md
+++ b/docs/0.29/reference/clients.md
@@ -512,7 +512,7 @@ The client definition uses the `{ "client": {} }` [configuration scope][24].
 `redact`
 : description
   : Client definition attributes to redact (values) when logging and sending
-    client keepalives.
+    client keepalives. When configuring this array, the default values will be overwritten, requiring them to be re-added to your array.
 : required
   : false
 : type

--- a/docs/1.0/reference/clients.md
+++ b/docs/1.0/reference/clients.md
@@ -512,7 +512,7 @@ The client definition uses the `{ "client": {} }` [configuration scope][24].
 `redact`
 : description
   : Client definition attributes to redact (values) when logging and sending
-    client keepalives.
+    client keepalives. When configuring this array, the default values will be overwritten, requiring them to be re-added to your array.
 : required
   : false
 : type


### PR DESCRIPTION
This was brought up in slack that it was not obvious to them that this was an override and assumed it was a merge operation. Regardless of changing this behavior if we want to (I don't think we should) I think we should minimally make the documention a bit clearer on this. We might also want to look at client at startup and emit a warning but that is out of the scope of this.

Signed-off-by: Ben Abrams <me@benabrams.it>