### PR TITLE
Restore 'ok' as allowed handler severity and add explanatory note

### DIFF
--- a/docs/0.23/reference/handlers.md
+++ b/docs/0.23/reference/handlers.md
@@ -273,6 +273,7 @@ The following attributes are configured within the `{"handlers": { "HANDLER": {}
 : description
   : An array of check result severities the handler will handle.
     _NOTE: event resolution bypasses this filtering._
+    _NOTE: specifying "ok" in handler severities will not cause the handler to recieve "ok" results from standard checks._
 : required
   : false
 : type

--- a/docs/0.23/reference/handlers.md
+++ b/docs/0.23/reference/handlers.md
@@ -278,7 +278,7 @@ The following attributes are configured within the `{"handlers": { "HANDLER": {}
 : type
   : Array
 : allowed values
-  : `warning`, `critical`, `unknown`
+  : `ok`, `warning`, `critical`, `unknown`
 : example
   : ~~~ shell
     "severities": ["critical", "unknown"]

--- a/docs/0.24/api/aggregates-api.md
+++ b/docs/0.24/api/aggregates-api.md
@@ -346,7 +346,7 @@ $ curl -s http://localhost:4567/aggregates/elasticsearch/results/critical | jq .
       - **type**: Integer
       - **description**: the maximum age of results to include, in seconds.
 : allowed values
-  : `warning`, `critical`, `unknown`
+  : `ok`, `warning`, `critical`, `unknown`
 : response codes
   : - **Success**: 200 (OK)
     - **Missing**: 404 (Not Found)

--- a/docs/0.24/reference/handlers.md
+++ b/docs/0.24/reference/handlers.md
@@ -274,6 +274,7 @@ The following attributes are configured within the `{"handlers": { "HANDLER": {}
 : description
   : An array of check result severities the handler will handle.
     _NOTE: event resolution bypasses this filtering._
+    _NOTE: specifying "ok" in handler severities will not cause the handler to recieve "ok" results from standard checks._
 : required
   : false
 : type

--- a/docs/0.24/reference/handlers.md
+++ b/docs/0.24/reference/handlers.md
@@ -279,7 +279,7 @@ The following attributes are configured within the `{"handlers": { "HANDLER": {}
 : type
   : Array
 : allowed values
-  : `warning`, `critical`, `unknown`
+  : `ok`, `warning`, `critical`, `unknown`
 : example
   : ~~~ shell
     "severities": ["critical", "unknown"]

--- a/docs/0.25/api/aggregates-api.md
+++ b/docs/0.25/api/aggregates-api.md
@@ -345,7 +345,7 @@ $ curl -s http://localhost:4567/aggregates/elasticsearch/results/critical | jq .
       - **type**: Integer
       - **description**: the maximum age of results to include, in seconds.
 : allowed values
-  : `warning`, `critical`, `unknown`
+  : `ok`, `warning`, `critical`, `unknown`
 : response codes
   : - **Success**: 200 (OK)
     - **Missing**: 404 (Not Found)

--- a/docs/0.25/reference/handlers.md
+++ b/docs/0.25/reference/handlers.md
@@ -274,6 +274,7 @@ The following attributes are configured within the `{"handlers": { "HANDLER": {}
 : description
   : An array of check result severities the handler will handle.
     _NOTE: event resolution bypasses this filtering._
+    _NOTE: specifying "ok" in handler severities will not cause the handler to recieve "ok" results from standard checks._
 : required
   : false
 : type

--- a/docs/0.25/reference/handlers.md
+++ b/docs/0.25/reference/handlers.md
@@ -279,7 +279,7 @@ The following attributes are configured within the `{"handlers": { "HANDLER": {}
 : type
   : Array
 : allowed values
-  : `warning`, `critical`, `unknown`
+  : `ok`, `warning`, `critical`, `unknown`
 : example
   : ~~~ shell
     "severities": ["critical", "unknown"]

--- a/docs/0.26/api/aggregates-api.md
+++ b/docs/0.26/api/aggregates-api.md
@@ -346,7 +346,7 @@ $ curl -s http://localhost:4567/aggregates/elasticsearch/results/critical | jq .
       - **type**: Integer
       - **description**: the maximum age of results to include, in seconds.
 : allowed values
-  : `warning`, `critical`, `unknown`
+  : `ok`, `warning`, `critical`, `unknown`
 : response codes
   : - **Success**: 200 (OK)
     - **Missing**: 404 (Not Found)

--- a/docs/0.26/reference/handlers.md
+++ b/docs/0.26/reference/handlers.md
@@ -292,7 +292,7 @@ The following attributes are configured within the `{"handlers": { "HANDLER": {}
 : type
   : Array
 : allowed values
-  : `warning`, `critical`, `unknown`
+  : `ok`, `warning`, `critical`, `unknown`
 : example
   : ~~~ shell
     "severities": ["critical", "unknown"]

--- a/docs/0.26/reference/handlers.md
+++ b/docs/0.26/reference/handlers.md
@@ -287,6 +287,7 @@ The following attributes are configured within the `{"handlers": { "HANDLER": {}
 : description
   : An array of check result severities the handler will handle.
     _NOTE: event resolution bypasses this filtering._
+    _NOTE: specifying "ok" in handler severities will not cause the handler to recieve "ok" results from standard checks._
 : required
   : false
 : type

--- a/docs/0.27/api/aggregates-api.md
+++ b/docs/0.27/api/aggregates-api.md
@@ -346,7 +346,7 @@ $ curl -s http://localhost:4567/aggregates/elasticsearch/results/critical | jq .
       - **type**: Integer
       - **description**: the maximum age of results to include, in seconds.
 : allowed values
-  : `warning`, `critical`, `unknown`
+  : `ok`, `warning`, `critical`, `unknown`
 : response codes
   : - **Success**: 200 (OK)
     - **Missing**: 404 (Not Found)

--- a/docs/0.27/reference/handlers.md
+++ b/docs/0.27/reference/handlers.md
@@ -292,7 +292,7 @@ The following attributes are configured within the `{"handlers": { "HANDLER": {}
 : type
   : Array
 : allowed values
-  : `warning`, `critical`, `unknown`
+  : `ok`, `warning`, `critical`, `unknown`
 : example
   : ~~~ shell
     "severities": ["critical", "unknown"]

--- a/docs/0.27/reference/handlers.md
+++ b/docs/0.27/reference/handlers.md
@@ -287,6 +287,7 @@ The following attributes are configured within the `{"handlers": { "HANDLER": {}
 : description
   : An array of check result severities the handler will handle.
     _NOTE: event resolution bypasses this filtering._
+    _NOTE: specifying "ok" in handler severities will not cause the handler to recieve "ok" results from standard checks._
 : required
   : false
 : type

--- a/docs/0.28/api/aggregates-api.md
+++ b/docs/0.28/api/aggregates-api.md
@@ -346,7 +346,7 @@ $ curl -s http://localhost:4567/aggregates/elasticsearch/results/critical | jq .
       - **type**: Integer
       - **description**: the maximum age of results to include, in seconds.
 : allowed values
-  : `warning`, `critical`, `unknown`
+  : `ok`, `warning`, `critical`, `unknown`
 : response codes
   : - **Success**: 200 (OK)
     - **Missing**: 404 (Not Found)

--- a/docs/0.28/reference/handlers.md
+++ b/docs/0.28/reference/handlers.md
@@ -292,7 +292,7 @@ The following attributes are configured within the `{"handlers": { "HANDLER": {}
 : type
   : Array
 : allowed values
-  : `warning`, `critical`, `unknown`
+  : `ok`, `warning`, `critical`, `unknown`
 : example
   : ~~~ shell
     "severities": ["critical", "unknown"]

--- a/docs/0.28/reference/handlers.md
+++ b/docs/0.28/reference/handlers.md
@@ -287,6 +287,7 @@ The following attributes are configured within the `{"handlers": { "HANDLER": {}
 : description
   : An array of check result severities the handler will handle.
     _NOTE: event resolution bypasses this filtering._
+    _NOTE: specifying "ok" in handler severities will not cause the handler to recieve "ok" results from standard checks._
 : required
   : false
 : type

--- a/docs/0.29/api/aggregates-api.md
+++ b/docs/0.29/api/aggregates-api.md
@@ -346,7 +346,7 @@ $ curl -s http://localhost:4567/aggregates/elasticsearch/results/critical | jq .
       - **type**: Integer
       - **description**: the maximum age of results to include, in seconds.
 : allowed values
-  : `warning`, `critical`, `unknown`
+  : `ok`, `warning`, `critical`, `unknown`
 : response codes
   : - **Success**: 200 (OK)
     - **Missing**: 404 (Not Found)

--- a/docs/0.29/reference/handlers.md
+++ b/docs/0.29/reference/handlers.md
@@ -292,7 +292,7 @@ The following attributes are configured within the `{"handlers": { "HANDLER": {}
 : type
   : Array
 : allowed values
-  : `warning`, `critical`, `unknown`
+  : `ok`, `warning`, `critical`, `unknown`
 : example
   : ~~~ shell
     "severities": ["critical", "unknown"]

--- a/docs/0.29/reference/handlers.md
+++ b/docs/0.29/reference/handlers.md
@@ -287,6 +287,7 @@ The following attributes are configured within the `{"handlers": { "HANDLER": {}
 : description
   : An array of check result severities the handler will handle.
     _NOTE: event resolution bypasses this filtering._
+    _NOTE: specifying "ok" in handler severities will not cause the handler to recieve "ok" results from standard checks._
 : required
   : false
 : type

--- a/docs/1.0/reference/handlers.md
+++ b/docs/1.0/reference/handlers.md
@@ -287,12 +287,13 @@ The following attributes are configured within the `{"handlers": { "HANDLER": {}
 : description
   : An array of check result severities the handler will handle.
     _NOTE: event resolution bypasses this filtering._
+    _NOTE: specifying "ok" in handler severities will not cause the handler to recieve "ok" results from standard checks._
 : required
   : false
 : type
   : Array
 : allowed values
-  : `warning`, `critical`, `unknown`
+  : `ok`, `warning`, `critical`, `unknown`
 : example
   : ~~~ shell
     "severities": ["critical", "unknown"]

--- a/docs/1.1/reference/handlers.md
+++ b/docs/1.1/reference/handlers.md
@@ -292,7 +292,7 @@ The following attributes are configured within the `{"handlers": { "HANDLER": {}
 : type
   : Array
 : allowed values
-  : `warning`, `critical`, `unknown`
+  : `ok`, `warning`, `critical`, `unknown`
 : example
   : ~~~ shell
     "severities": ["critical", "unknown"]

--- a/legacy/0.17/handlers.md
+++ b/legacy/0.17/handlers.md
@@ -124,7 +124,7 @@ severities
 : type
   : Array
 : allowed values
-  : `warning`, `critical`, `unknown`
+  : `ok`, `warning`, `critical`, `unknown`
 : example
   : ~~~ shell
     "severities": ["critical", "unknown"]

--- a/legacy/0.18/handlers.md
+++ b/legacy/0.18/handlers.md
@@ -124,7 +124,7 @@ severities
 : type
   : Array
 : allowed values
-  : `warning`, `critical`, `unknown`
+  : `ok`, `warning`, `critical`, `unknown`
 : example
   : ~~~ shell
     "severities": ["critical", "unknown"]

--- a/legacy/0.19/handlers.md
+++ b/legacy/0.19/handlers.md
@@ -124,7 +124,7 @@ severities
 : type
   : Array
 : allowed values
-  : `warning`, `critical`, `unknown`
+  : `ok`, `warning`, `critical`, `unknown`
 : example
   : ~~~ shell
     "severities": ["critical", "unknown"]

--- a/legacy/0.20/handlers.md
+++ b/legacy/0.20/handlers.md
@@ -124,7 +124,7 @@ severities
 : type
   : Array
 : allowed values
-  : `warning`, `critical`, `unknown`
+  : `ok`, `warning`, `critical`, `unknown`
 : example
   : ~~~ shell
     "severities": ["critical", "unknown"]

--- a/legacy/0.21/handlers.md
+++ b/legacy/0.21/handlers.md
@@ -124,7 +124,7 @@ severities
 : type
   : Array
 : allowed values
-  : `warning`, `critical`, `unknown`
+  : `ok`, `warning`, `critical`, `unknown`
 : example
   : ~~~ shell
     "severities": ["critical", "unknown"]

--- a/legacy/0.22/handlers.md
+++ b/legacy/0.22/handlers.md
@@ -124,7 +124,7 @@ severities
 : type
   : Array
 : allowed values
-  : `warning`, `critical`, `unknown`
+  : `ok`, `warning`, `critical`, `unknown`
 : example
   : ~~~ shell
     "severities": ["critical", "unknown"]


### PR DESCRIPTION
In #598 we removed "ok" as an allowed handler severity. This was done to avoid creating the impression that specifying "ok" as an allowed severity will cause "ok" results from standard checks to be passed to handlers. Unfortunately removing "ok" from the list of allowed values has created a different kind of confusion.

This change reverts the commit from #598 and adds an additional note indicating that specifying "ok" severity on a handler will not cause "ok" results from standard checks to be handled.