### PR TITLE
Sentinel does not yet fully support protected mode

### DIFF
--- a/docs/0.29/files/sentinel.conf
+++ b/docs/0.29/files/sentinel.conf
@@ -1,3 +1,5 @@
+protected_mode no
+
 daemonize yes
 pidfile /var/run/redis/redis-sentinel.pid
 


### PR DESCRIPTION
By default protected_mode is enabled.
Disabling this allows sentinels to talk to each other even if you set password on the redis master.