### PR TITLE
Update results-api.md

### DIFF
--- a/docs/1.1/api/results-api.md
+++ b/docs/1.1/api/results-api.md
@@ -163,9 +163,11 @@ Server: thin
        "status": 0
      }
     ~~~
-    _NOTE: the `/results` (POST) API only supports check `name`, `output`,
-    `status`, and `source` (used to create a [proxy client][4]). Please see the
-    [check definition specification][5] documentation for more information._
+    _NOTE: the `/results` (POST) API *requires* the following four fields: `name`, `output`,
+    `status`, and `source` (the fields used to create a [proxy client][4]). You can optionally 
+    add other fields supported in check results, such as `handler` to specify a handler of 
+    your choosing. Please see the [check definition specification][5] documentation for more 
+    information._
 : output
   : ~~~ shell
     HTTP/1.1 202 Accepted


### PR DESCRIPTION
The current docs for POST against the `/results` API states that only `name`, `source`, `output`, and `status` are supported. Perhaps that might have been the case in the past, but at least as of 1.0.1 (pretty sure I did the same against 0.26 or so), it accepts other fields like `handler`/`handlers` as well as custom user-defined fields.