### PR TITLE
[Enterprise] RBAC missing attributes

### DIFF
--- a/docs/1.1/enterprise/rbac/overview.md
+++ b/docs/1.1/enterprise/rbac/overview.md
@@ -188,7 +188,7 @@ specification is common across all RBAC drivers.
   : An array of the LDAP groups, GitHub Teams, or GitLab Groups that should be
     included as members of the role.
 : required
-  : true
+  : true (unless `fallback` is `true`)
 : type
   : Array
 : allowed values
@@ -206,6 +206,24 @@ specification is common across all RBAC drivers.
       "myorganization/devs",
       "myorganization/ops"
     ]
+    ~~~
+
+`fallback`
+: description
+  : Sets the role as a fallback role, which is assigned to users that are
+    successfully authenticated but not authorized by any other role.
+    _NOTE: Only a single fallback role can be defined._
+    _NOTE: The `fallback` attribute can't be used in conjunction with the
+    the `members` attribute._
+: required
+  : true (unless `members` is defined)
+: type
+  : Boolean
+: default
+  : false
+: example
+  : ~~~ shell
+    "fallback": true
     ~~~
 
 `datacenters`

--- a/docs/1.1/enterprise/rbac/rbac-for-ldap.md
+++ b/docs/1.1/enterprise/rbac/rbac-for-ldap.md
@@ -367,6 +367,20 @@ compatible with any standards-compliant LDAP provider.
     "groupobjectclass": "posixGroup"
     ~~~
 
+`disablenestedgroups`
+: description
+  : Disables support for nested groups, in order to avoid recursive queries.
+: required
+  : false
+: type
+  : Boolean
+: default
+  : false
+: example
+  : ~~~ shell
+    "disablenestedgroups": true
+    ~~~
+
 #### `roles` attributes
 
 Please see the [RBAC definition specification][4] for information on how to


### PR DESCRIPTION
It adds documentation for two RBAC attributes that were missing.

- `fallback` attribute for roles
- `disablenestedgroups` attribute for the LDAP servers