### PR TITLE
Fixing broken links in "Intro to Mutators"

### DIFF
--- a/docs/0.23/guides/getting-started/intro-to-mutators.md
+++ b/docs/0.23/guides/getting-started/intro-to-mutators.md
@@ -39,5 +39,5 @@ Coming soon. Please see the [Mutators][1] reference documentation. If you have
 questions about event data mutators, please contact [Sensu Support][2].
 
 
-[1]:  ../reference/mutators.html
+[1]:  ../../reference/mutators.html
 [2]:  http://helpdesk.sensuapp.com

--- a/docs/0.24/guides/getting-started/intro-to-mutators.md
+++ b/docs/0.24/guides/getting-started/intro-to-mutators.md
@@ -39,5 +39,5 @@ Coming soon. Please see the [Mutators][1] reference documentation. If you have
 questions about event data mutators, please contact [Sensu Support][2].
 
 
-[1]:  ../reference/mutators.html
+[1]:  ../../reference/mutators.html
 [2]:  http://helpdesk.sensuapp.com

--- a/docs/0.25/guides/getting-started/intro-to-mutators.md
+++ b/docs/0.25/guides/getting-started/intro-to-mutators.md
@@ -39,5 +39,5 @@ Coming soon. Please see the [Mutators][1] reference documentation. If you have
 questions about event data mutators, please contact [Sensu Support][2].
 
 
-[1]:  ../reference/mutators.html
+[1]:  ../../reference/mutators.html
 [2]:  http://helpdesk.sensuapp.com

--- a/docs/0.26/guides/getting-started/intro-to-mutators.md
+++ b/docs/0.26/guides/getting-started/intro-to-mutators.md
@@ -39,5 +39,5 @@ Coming soon. Please see the [Mutators][1] reference documentation. If you have
 questions about event data mutators, please contact [Sensu Support][2].
 
 
-[1]:  ../reference/mutators.html
+[1]:  ../../reference/mutators.html
 [2]:  http://helpdesk.sensuapp.com

--- a/docs/0.27/guides/getting-started/intro-to-mutators.md
+++ b/docs/0.27/guides/getting-started/intro-to-mutators.md
@@ -39,5 +39,5 @@ Coming soon. Please see the [Mutators][1] reference documentation. If you have
 questions about event data mutators, please contact [Sensu Support][2].
 
 
-[1]:  ../reference/mutators.html
+[1]:  ../../reference/mutators.html
 [2]:  http://helpdesk.sensuapp.com

--- a/docs/0.28/guides/getting-started/intro-to-mutators.md
+++ b/docs/0.28/guides/getting-started/intro-to-mutators.md
@@ -39,5 +39,5 @@ Coming soon. Please see the [Mutators][1] reference documentation. If you have
 questions about event data mutators, please contact [Sensu Support][2].
 
 
-[1]:  ../reference/mutators.html
+[1]:  ../../reference/mutators.html
 [2]:  http://helpdesk.sensuapp.com

--- a/docs/0.29/guides/getting-started/intro-to-mutators.md
+++ b/docs/0.29/guides/getting-started/intro-to-mutators.md
@@ -39,5 +39,5 @@ Coming soon. Please see the [Mutators][1] reference documentation. If you have
 questions about event data mutators, please contact [Sensu Support][2].
 
 
-[1]:  ../reference/mutators.html
+[1]:  ../../reference/mutators.html
 [2]:  http://helpdesk.sensuapp.com

--- a/docs/1.0/guides/getting-started/intro-to-mutators.md
+++ b/docs/1.0/guides/getting-started/intro-to-mutators.md
@@ -39,5 +39,5 @@ Coming soon. Please see the [Mutators][1] reference documentation. If you have
 questions about event data mutators, please contact [Sensu Support][2].
 
 
-[1]:  ../reference/mutators.html
+[1]:  ../../reference/mutators.html
 [2]:  http://helpdesk.sensuapp.com

--- a/docs/1.1/guides/getting-started/intro-to-mutators.md
+++ b/docs/1.1/guides/getting-started/intro-to-mutators.md
@@ -39,5 +39,5 @@ Coming soon. Please see the [Mutators][1] reference documentation. If you have
 questions about event data mutators, please contact [Sensu Support][2].
 
 
-[1]:  ../reference/mutators.html
+[1]:  ../../reference/mutators.html
 [2]:  http://helpdesk.sensuapp.com


### PR DESCRIPTION
All versions of the docs had a broken link in the intro-to-mutators article pointing to a non-existent page. This should now be corrected. @cwjohnston can I get a :+1: or :-1: 