### PR TITLE
Call out that standalone checks will not be displayed by /checks API

### DIFF
--- a/docs/0.23/api/checks-api.md
+++ b/docs/0.23/api/checks-api.md
@@ -44,6 +44,10 @@ $ curl -s http://127.0.0.1:4567/checks | jq .
 ]
 ~~~
 
+_NOTE: The `/checks` API reads check configuration from disk; as such
+check definitions must exist on your API servers to be displayed by the API.
+Due to this standalone checks **will not** be displayed by the `/checks` API._
+
 #### API Specification {#checks-get-specification}
 
 `/checks` (GET)

--- a/docs/0.24/api/checks-api.md
+++ b/docs/0.24/api/checks-api.md
@@ -44,6 +44,10 @@ $ curl -s http://127.0.0.1:4567/checks | jq .
 ]
 ~~~
 
+_NOTE: The `/checks` API reads check configuration from disk; as such
+check definitions must exist on your API servers to be displayed by the API.
+Due to this standalone checks **will not** be displayed by the `/checks` API._
+
 #### API Specification {#checks-get-specification}
 
 `/checks` (GET)

--- a/docs/0.25/api/checks-api.md
+++ b/docs/0.25/api/checks-api.md
@@ -44,6 +44,10 @@ $ curl -s http://127.0.0.1:4567/checks | jq .
 ]
 ~~~
 
+_NOTE: The `/checks` API reads check configuration from disk; as such
+check definitions must exist on your API servers to be displayed by the API.
+Due to this standalone checks **will not** be displayed by the `/checks` API._
+
 #### API Specification {#checks-get-specification}
 
 `/checks` (GET)

--- a/docs/0.26/api/checks-api.md
+++ b/docs/0.26/api/checks-api.md
@@ -44,6 +44,10 @@ $ curl -s http://127.0.0.1:4567/checks | jq .
 ]
 ~~~
 
+_NOTE: The `/checks` API reads check configuration from disk; as such
+check definitions must exist on your API servers to be displayed by the API.
+Due to this standalone checks **will not** be displayed by the `/checks` API._
+
 #### API Specification {#checks-get-specification}
 
 `/checks` (GET)

--- a/docs/0.27/api/checks-api.md
+++ b/docs/0.27/api/checks-api.md
@@ -44,6 +44,10 @@ $ curl -s http://127.0.0.1:4567/checks | jq .
 ]
 ~~~
 
+_NOTE: The `/checks` API reads check configuration from disk; as such
+check definitions must exist on your API servers to be displayed by the API.
+Due to this standalone checks **will not** be displayed by the `/checks` API._
+
 #### API Specification {#checks-get-specification}
 
 `/checks` (GET)

--- a/docs/0.28/api/checks-api.md
+++ b/docs/0.28/api/checks-api.md
@@ -44,6 +44,10 @@ $ curl -s http://127.0.0.1:4567/checks | jq .
 ]
 ~~~
 
+_NOTE: The `/checks` API reads check configuration from disk; as such
+check definitions must exist on your API servers to be displayed by the API.
+Due to this standalone checks **will not** be displayed by the `/checks` API._
+
 #### API Specification {#checks-get-specification}
 
 `/checks` (GET)

--- a/docs/0.29/api/checks-api.md
+++ b/docs/0.29/api/checks-api.md
@@ -44,6 +44,10 @@ $ curl -s http://127.0.0.1:4567/checks | jq .
 ]
 ~~~
 
+_NOTE: The `/checks` API reads check configuration from disk; as such
+check definitions must exist on your API servers to be displayed by the API.
+Due to this standalone checks **will not** be displayed by the `/checks` API._
+
 #### API Specification {#checks-get-specification}
 
 `/checks` (GET)

--- a/docs/1.0/api/checks-api.md
+++ b/docs/1.0/api/checks-api.md
@@ -44,6 +44,10 @@ $ curl -s http://127.0.0.1:4567/checks | jq .
 ]
 ~~~
 
+_NOTE: The `/checks` API reads check configuration from disk; as such
+check definitions must exist on your API servers to be displayed by the API.
+Due to this standalone checks **will not** be displayed by the `/checks` API._
+
 #### API Specification {#checks-get-specification}
 
 `/checks` (GET)

--- a/docs/1.1/api/checks-api.md
+++ b/docs/1.1/api/checks-api.md
@@ -44,6 +44,10 @@ $ curl -s http://127.0.0.1:4567/checks | jq .
 ]
 ~~~
 
+_NOTE: The `/checks` API reads check configuration from disk; as such
+check definitions must exist on your API servers to be displayed by the API.
+Due to this standalone checks **will not** be displayed by the `/checks` API._
+
 #### API Specification {#checks-get-specification}
 
 `/checks` (GET)


### PR DESCRIPTION
As per #654 add a note to point out:

- The API reads checks from configuration disk. As such, in circumstances where sensu-api is ran on separate instances, check configurations must still exist.
- Standalone checks will not be returned by the `/checks` API

I've stuck it under the first example of `GET /checks`, might be better somewhere else