### PR TITLE
Add docs for disabling client sockets

### DIFF
--- a/docs/1.2/reference/clients.md
+++ b/docs/1.2/reference/clients.md
@@ -699,6 +699,20 @@ The following attributes are configured within the `{ "client": { "socket": {} }
 
 ##### ATTRIBUTES {#socket-attributes-specification}
 
+`enabled`
+: description
+  : Allows for disabling the client TCP and UDP socket.
+: required
+  : false
+: type
+  : Boolean
+: default
+  : `true`
+: example
+  : ~~~ shell
+    "enabled": "false"
+    ~~~
+
 `bind`
 : description
   : The address to bind the Sensu client socket to.
@@ -750,6 +764,20 @@ The following attributes are configured within the `{ "client": { "http_socket":
 ~~~
 
 ##### ATTRIBUTES {#http-socket-attributes-specification}
+
+`enabled`
+: description
+  : Allows for disabling the client HTTP socket.
+: required
+  : false
+: type
+  : Boolean
+: default
+  : `true`
+: example
+  : ~~~ shell
+    "enabled": "false"
+    ~~~
 
 `bind`
 : description


### PR DESCRIPTION
Adding docs for https://github.com/sensu/sensu/issues/1799 and https://github.com/sensu/sensu/pull/1800, I'm not entirely sure I did this correctly. I also documented the already existing `enabled` attribute for the HTTP socket as well. 