### PR TITLE
Fix top links for silenced API doc

### DIFF
--- a/docs/1.2/api/silenced-api.md
+++ b/docs/1.2/api/silenced-api.md
@@ -15,9 +15,9 @@ next:
   - [`/silenced` (GET)](#silenced-get)
   - [`/silenced` (POST)](#silenced-post)
   - [`/silenced/ids/:id` (GET)](#silencedidsid-get)
-  - [`/silenced/clear` (POST)](#silenced-clear-post)
-  - [`/silenced/subscriptions/:subscription` (GET)](#silenced-subscriptions-get)
-  - [`/silenced/checks/:check` (GET)](#silenced-checks-get)
+  - [`/silenced/clear` (POST)](#silencedclear-post)
+  - [`/silenced/subscriptions/:subscription` (GET)](#silencedsubscriptionssubscription-get)
+  - [`/silenced/checks/:check` (GET)](#silencedcheckscheck-get)
 
 ## The `/silenced` API endpoints
 


### PR DESCRIPTION
The format seems to be the request path (excluding slashes) and the request
method joined by a hyphen.