### PR TITLE
Add dev subscriber to check_http check in "Learn Sensu in 15 Minutes"

### DIFF
--- a/docs/1.2/quick-start/learn-sensu-basics.md
+++ b/docs/1.2/quick-start/learn-sensu-basics.md
@@ -233,7 +233,7 @@ this execution will be handled by the Sensu server.
        "check_http": {
          "command": "/usr/lib64/nagios/plugins/check_http -I 127.0.0.1",
          "interval": 10,
-         "subscribers": ["webserver"]
+         "subscribers": ["webserver", "dev"]
        }
      }
    }
@@ -258,14 +258,15 @@ this execution will be handled by the Sensu server.
    ~~~ shell
    $ curl -s 127.0.0.1:4567/checks | jq .
    [
-      {
-        "command": "/usr/lib64/nagios/plugins/check_http -H 127.0.0.1",
-        "interval": 10,
-        "subscribers": [
-        "webserver"
-        ],
-        "name": "check_http"
-      }
+     {
+       "command": "/usr/lib64/nagios/plugins/check_http -I 127.0.0.1",
+       "interval": 10,
+       "subscribers": [
+         "webserver",
+         "dev"
+       ],
+       "name": "check_http"
+     }
    ]
    ~~~
 


### PR DESCRIPTION
When following the instructions for Exercise 2 the test client (client-01) doesn't receive the check_http check request.  This is because the client config only references the `dev` subscription and the check_http config only references the `webserver` subscriber.

This edit adds the `dev` subscriber to the suggested check_http config.  