### PR TITLE
Clarify the purpose of the check_result_monitor task

### DIFF
--- a/docs/0.24/reference/server.md
+++ b/docs/0.24/reference/server.md
@@ -118,8 +118,8 @@ by the Sensu server leader:
   [check execution scheduling][18] for more information.
 - **Client monitor**. The Sensu server leader is responsible for monitoring the
   [client registry][19] and creating [client keepalive events][20] for stale clients.
-- **Check result monitor**. The Sensu server leader is responsible for
-  monitoring check results and creating TTL events for check results with
+- **Check result monitor**. The Sensu server leader is responsible for monitoring the
+  age of check results and creating TTL events for check results with
   expired [check TTLs][21]
 - **Check result aggregation pruning**. The Sensu server leader is responsible
   for monitoring check aggregates and pruning stale aggregate results.

--- a/docs/0.25/reference/server.md
+++ b/docs/0.25/reference/server.md
@@ -118,7 +118,7 @@ by the Sensu server leader:
   [check execution scheduling][18] for more information.
 - **Client monitor**. The Sensu server leader is responsible for monitoring the
   [client registry][19] and creating [client keepalive events][20] for stale clients.
-- **Check result monitor**. The Sensu server is responsible for monitoring the
+- **Check result monitor**. The Sensu server leader is responsible for monitoring the
   age of check results and creating TTL events for check results with
   expired [check TTLs][21]
 - **Check result aggregation pruning**. The Sensu server leader is responsible

--- a/docs/0.25/reference/server.md
+++ b/docs/0.25/reference/server.md
@@ -118,8 +118,8 @@ by the Sensu server leader:
   [check execution scheduling][18] for more information.
 - **Client monitor**. The Sensu server leader is responsible for monitoring the
   [client registry][19] and creating [client keepalive events][20] for stale clients.
-- **Check result monitor**. The Sensu server leader is responsible for
-  monitoring check results and creating TTL events for check results with
+- **Check result monitor**. The Sensu server is responsible for monitoring the
+  age of check results and creating TTL events for check results with
   expired [check TTLs][21]
 - **Check result aggregation pruning**. The Sensu server leader is responsible
   for monitoring check aggregates and pruning stale aggregate results.

--- a/docs/0.26/reference/server.md
+++ b/docs/0.26/reference/server.md
@@ -118,7 +118,7 @@ by the Sensu server leader:
   [check execution scheduling][18] for more information.
 - **Client monitor**. The Sensu server leader is responsible for monitoring the
   [client registry][19] and creating [client keepalive events][20] for stale clients.
-- **Check result monitor**. The Sensu server is responsible for monitoring the
+- **Check result monitor**. The Sensu server leader is responsible for monitoring the
   age of check results and creating TTL events for check results with
   expired [check TTLs][21]
 - **Check result aggregation pruning**. The Sensu server leader is responsible

--- a/docs/0.26/reference/server.md
+++ b/docs/0.26/reference/server.md
@@ -118,8 +118,8 @@ by the Sensu server leader:
   [check execution scheduling][18] for more information.
 - **Client monitor**. The Sensu server leader is responsible for monitoring the
   [client registry][19] and creating [client keepalive events][20] for stale clients.
-- **Check result monitor**. The Sensu server leader is responsible for
-  monitoring check results and creating TTL events for check results with
+- **Check result monitor**. The Sensu server is responsible for monitoring the
+  age of check results and creating TTL events for check results with
   expired [check TTLs][21]
 - **Check result aggregation pruning**. The Sensu server leader is responsible
   for monitoring check aggregates and pruning stale aggregate results.

--- a/docs/0.27/reference/server.md
+++ b/docs/0.27/reference/server.md
@@ -118,7 +118,7 @@ by the Sensu server leader:
   [check execution scheduling][18] for more information.
 - **Client monitor**. The Sensu server leader is responsible for monitoring the
   [client registry][19] and creating [client keepalive events][20] for stale clients.
-- **Check result monitor**. The Sensu server is responsible for monitoring the
+- **Check result monitor**. The Sensu server leader is responsible for monitoring the
   age of check results and creating TTL events for check results with
   expired [check TTLs][21]
 - **Check result aggregation pruning**. The Sensu server leader is responsible

--- a/docs/0.27/reference/server.md
+++ b/docs/0.27/reference/server.md
@@ -118,8 +118,8 @@ by the Sensu server leader:
   [check execution scheduling][18] for more information.
 - **Client monitor**. The Sensu server leader is responsible for monitoring the
   [client registry][19] and creating [client keepalive events][20] for stale clients.
-- **Check result monitor**. The Sensu server leader is responsible for
-  monitoring check results and creating TTL events for check results with
+- **Check result monitor**. The Sensu server is responsible for monitoring the
+  age of check results and creating TTL events for check results with
   expired [check TTLs][21]
 - **Check result aggregation pruning**. The Sensu server leader is responsible
   for monitoring check aggregates and pruning stale aggregate results.

--- a/docs/0.28/reference/server.md
+++ b/docs/0.28/reference/server.md
@@ -118,7 +118,7 @@ by the Sensu server leader:
   [check execution scheduling][18] for more information.
 - **Client monitor**. The Sensu server leader is responsible for monitoring the
   [client registry][19] and creating [client keepalive events][20] for stale clients.
-- **Check result monitor**. The Sensu server is responsible for monitoring the
+- **Check result monitor**. The Sensu server leader is responsible for monitoring the
   age of check results and creating TTL events for check results with
   expired [check TTLs][21]
 - **Check result aggregation pruning**. The Sensu server leader is responsible

--- a/docs/0.28/reference/server.md
+++ b/docs/0.28/reference/server.md
@@ -118,8 +118,8 @@ by the Sensu server leader:
   [check execution scheduling][18] for more information.
 - **Client monitor**. The Sensu server leader is responsible for monitoring the
   [client registry][19] and creating [client keepalive events][20] for stale clients.
-- **Check result monitor**. The Sensu server leader is responsible for
-  monitoring check results and creating TTL events for check results with
+- **Check result monitor**. The Sensu server is responsible for monitoring the
+  age of check results and creating TTL events for check results with
   expired [check TTLs][21]
 - **Check result aggregation pruning**. The Sensu server leader is responsible
   for monitoring check aggregates and pruning stale aggregate results.

--- a/docs/0.29/reference/server.md
+++ b/docs/0.29/reference/server.md
@@ -129,8 +129,8 @@ the cluster will force a redistribution of tasks.
   the [client registry][19] and creating [client keepalive events][20]
   for stale clients.
 - **Check result monitor**. The Sensu server is responsible for
-  monitoring check results and creating TTL events for check results
-  with expired [check TTLs][21]
+  monitoring the age of check results and creating TTL events for
+  check results with expired [check TTLs][21]
 - **Check result aggregation pruning**. The Sensu server is
   responsible for monitoring check aggregates and pruning stale
   aggregate results.

--- a/docs/1.0/reference/server.md
+++ b/docs/1.0/reference/server.md
@@ -129,8 +129,8 @@ the cluster will force a redistribution of tasks.
   the [client registry][19] and creating [client keepalive events][20]
   for stale clients.
 - **Check result monitor**. The Sensu server is responsible for
-  monitoring check results and creating TTL events for check results
-  with expired [check TTLs][21]
+  monitoring the age of check results and creating TTL events for
+  check results with expired [check TTLs][21]
 - **Check result aggregation pruning**. The Sensu server is
   responsible for monitoring check aggregates and pruning stale
   aggregate results.

--- a/docs/1.1/reference/server.md
+++ b/docs/1.1/reference/server.md
@@ -129,8 +129,8 @@ the cluster will force a redistribution of tasks.
   the [client registry][19] and creating [client keepalive events][20]
   for stale clients.
 - **Check result monitor**. The Sensu server is responsible for
-  monitoring check results and creating TTL events for check results
-  with expired [check TTLs][21]
+  monitoring the age of check results and creating TTL events for
+  check results with expired [check TTLs][21]
 - **Check result aggregation pruning**. The Sensu server is
   responsible for monitoring check aggregates and pruning stale
   aggregate results.

--- a/docs/1.2/reference/server.md
+++ b/docs/1.2/reference/server.md
@@ -129,8 +129,8 @@ the cluster will force a redistribution of tasks.
   the [client registry][19] and creating [client keepalive events][20]
   for stale clients.
 - **Check result monitor**. The Sensu server is responsible for
-  monitoring check results and creating TTL events for check results
-  with expired [check TTLs][21]
+  monitoring the age of check results and creating TTL events for
+  check results with expired [check TTLs][21]
 - **Check result aggregation pruning**. The Sensu server is
   responsible for monitoring check aggregates and pruning stale
   aggregate results.


### PR DESCRIPTION
A community member was asking on Slack how to scale Sensu horizontally when the `check_result_monitor` task is the only task for consuming the results queue on the transport. This is incorrect, as all servers are responsible for this and the `check_result_monitor` is for monitoring the TTL of check results. Re-worded this slightly in the docs to ensure this is clear.
  