### PR TITLE
Document severities and filters on Enterprise notification integration attributes

### DIFF
--- a/docs/0.24/enterprise/integrations/chef.md
+++ b/docs/0.24/enterprise/integrations/chef.md
@@ -186,6 +186,39 @@ The following attributes are configured within the `{"chef": {} }`
     "proxy_password": "secret"
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/0.24/enterprise/integrations/datadog.md
+++ b/docs/0.24/enterprise/integrations/datadog.md
@@ -56,6 +56,39 @@ The following attributes are configured within the `{"datadog": {} }`
     "api_key": "9775a026f1ca7d1c6c5af9d94d9595a4"
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/0.24/enterprise/integrations/email.md
+++ b/docs/0.24/enterprise/integrations/email.md
@@ -111,6 +111,39 @@ The following attributes are configured within the `{"email": {} }`
     "from": "noreply@example.com"
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/0.24/enterprise/integrations/hipchat.md
+++ b/docs/0.24/enterprise/integrations/hipchat.md
@@ -113,6 +113,39 @@ The following attributes are configured within the `{"hipchat": {} }`
     "room": "Search"
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/0.24/enterprise/integrations/irc.md
+++ b/docs/0.24/enterprise/integrations/irc.md
@@ -110,6 +110,39 @@ scope][2].
     "join": true
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/0.24/enterprise/integrations/opsgenie.md
+++ b/docs/0.24/enterprise/integrations/opsgenie.md
@@ -130,6 +130,39 @@ The following attributes are configured within the `{"opsgenie": {} }`
     "overwrites_quiet_hours": true
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/0.24/enterprise/integrations/pagerduty.md
+++ b/docs/0.24/enterprise/integrations/pagerduty.md
@@ -56,6 +56,39 @@ The following attributes are configured within the `{"pagerduty": {} }`
     "service_key": "r3FPuDvNOTEDyQYCc7trBkymIFcy2NkE"
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/0.24/enterprise/integrations/servicenow.md
+++ b/docs/0.24/enterprise/integrations/servicenow.md
@@ -146,6 +146,39 @@ The following attributes are configured within the `{"servicenow": {} }`
     "cmdb_ci_table": "cmdb_ci_sensu_client"
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/0.24/enterprise/integrations/slack.md
+++ b/docs/0.24/enterprise/integrations/slack.md
@@ -100,6 +100,39 @@ The following attributes are configured within the `{"slack": {} }`
     "icon_url": "http://www.gravatar.com/avatar/9b37917076cee4e2d331a785f3426640"
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/0.24/enterprise/integrations/snmp.md
+++ b/docs/0.24/enterprise/integrations/snmp.md
@@ -110,6 +110,38 @@ The following attributes are configured within the `{"snmp": {} }`
     "community": "private"
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
 
 
 [?]:  #

--- a/docs/0.24/enterprise/integrations/victorops.md
+++ b/docs/0.24/enterprise/integrations/victorops.md
@@ -69,6 +69,39 @@ The following attributes are configured within the `{"victorops": {} }`
     "routing_key": "ops"
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/0.25/enterprise/integrations/chef.md
+++ b/docs/0.25/enterprise/integrations/chef.md
@@ -186,6 +186,39 @@ The following attributes are configured within the `{"chef": {} }`
     "proxy_password": "secret"
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/0.25/enterprise/integrations/datadog.md
+++ b/docs/0.25/enterprise/integrations/datadog.md
@@ -56,6 +56,39 @@ The following attributes are configured within the `{"datadog": {} }`
     "api_key": "9775a026f1ca7d1c6c5af9d94d9595a4"
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/0.25/enterprise/integrations/email.md
+++ b/docs/0.25/enterprise/integrations/email.md
@@ -111,6 +111,39 @@ The following attributes are configured within the `{"email": {} }`
     "from": "noreply@example.com"
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/0.25/enterprise/integrations/hipchat.md
+++ b/docs/0.25/enterprise/integrations/hipchat.md
@@ -113,6 +113,39 @@ The following attributes are configured within the `{"hipchat": {} }`
     "room": "Search"
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/0.25/enterprise/integrations/irc.md
+++ b/docs/0.25/enterprise/integrations/irc.md
@@ -110,6 +110,39 @@ scope][2].
     "join": true
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/0.25/enterprise/integrations/opsgenie.md
+++ b/docs/0.25/enterprise/integrations/opsgenie.md
@@ -130,6 +130,39 @@ The following attributes are configured within the `{"opsgenie": {} }`
     "overwrites_quiet_hours": true
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/0.25/enterprise/integrations/pagerduty.md
+++ b/docs/0.25/enterprise/integrations/pagerduty.md
@@ -56,6 +56,39 @@ The following attributes are configured within the `{"pagerduty": {} }`
     "service_key": "r3FPuDvNOTEDyQYCc7trBkymIFcy2NkE"
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/0.25/enterprise/integrations/servicenow.md
+++ b/docs/0.25/enterprise/integrations/servicenow.md
@@ -146,6 +146,39 @@ The following attributes are configured within the `{"servicenow": {} }`
     "cmdb_ci_table": "cmdb_ci_sensu_client"
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/0.25/enterprise/integrations/snmp.md
+++ b/docs/0.25/enterprise/integrations/snmp.md
@@ -110,6 +110,38 @@ The following attributes are configured within the `{"snmp": {} }`
     "community": "private"
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
 
 
 [?]:  #

--- a/docs/0.25/enterprise/integrations/victorops.md
+++ b/docs/0.25/enterprise/integrations/victorops.md
@@ -69,6 +69,39 @@ The following attributes are configured within the `{"victorops": {} }`
     "routing_key": "ops"
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/0.26/enterprise/integrations/chef.md
+++ b/docs/0.26/enterprise/integrations/chef.md
@@ -186,6 +186,39 @@ The following attributes are configured within the `{"chef": {} }`
     "proxy_password": "secret"
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/0.26/enterprise/integrations/datadog.md
+++ b/docs/0.26/enterprise/integrations/datadog.md
@@ -56,6 +56,39 @@ The following attributes are configured within the `{"datadog": {} }`
     "api_key": "9775a026f1ca7d1c6c5af9d94d9595a4"
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/0.26/enterprise/integrations/email.md
+++ b/docs/0.26/enterprise/integrations/email.md
@@ -164,6 +164,39 @@ The following attributes are configured within the `{"email": {} }`
     }
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/0.26/enterprise/integrations/hipchat.md
+++ b/docs/0.26/enterprise/integrations/hipchat.md
@@ -130,6 +130,39 @@ The following attributes are configured within the `{"hipchat": {} }`
     "notify": true
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/0.26/enterprise/integrations/irc.md
+++ b/docs/0.26/enterprise/integrations/irc.md
@@ -110,6 +110,39 @@ scope][2].
     "join": true
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/0.26/enterprise/integrations/jira.md
+++ b/docs/0.26/enterprise/integrations/jira.md
@@ -122,6 +122,39 @@ The following attributes are configured within the `{"jira": {} }`
     "root_url": "https://services.example.com/proxy/jira"
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/0.26/enterprise/integrations/opsgenie.md
+++ b/docs/0.26/enterprise/integrations/opsgenie.md
@@ -130,6 +130,39 @@ The following attributes are configured within the `{"opsgenie": {} }`
     "overwrites_quiet_hours": true
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/0.26/enterprise/integrations/pagerduty.md
+++ b/docs/0.26/enterprise/integrations/pagerduty.md
@@ -56,6 +56,39 @@ The following attributes are configured within the `{"pagerduty": {} }`
     "service_key": "r3FPuDvNOTEDyQYCc7trBkymIFcy2NkE"
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/0.26/enterprise/integrations/rollbar.md
+++ b/docs/0.26/enterprise/integrations/rollbar.md
@@ -80,6 +80,39 @@ The following attributes are configured within the `{"rollbar": {} }`
     "access_token_patch": "f34948101a714661a83dcd8dbe6a167a"
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/0.26/enterprise/integrations/servicenow.md
+++ b/docs/0.26/enterprise/integrations/servicenow.md
@@ -219,6 +219,39 @@ The following attributes are configured within the `{"servicenow": {} }`
     "root_url": "https://services.example.com/proxy/servicenow/api"
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/0.26/enterprise/integrations/snmp.md
+++ b/docs/0.26/enterprise/integrations/snmp.md
@@ -110,6 +110,38 @@ The following attributes are configured within the `{"snmp": {} }`
     "community": "private"
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
 
 
 [?]:  #

--- a/docs/0.26/enterprise/integrations/victorops.md
+++ b/docs/0.26/enterprise/integrations/victorops.md
@@ -69,6 +69,39 @@ The following attributes are configured within the `{"victorops": {} }`
     "routing_key": "ops"
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/0.27/enterprise/integrations/chef.md
+++ b/docs/0.27/enterprise/integrations/chef.md
@@ -186,6 +186,39 @@ The following attributes are configured within the `{"chef": {} }`
     "proxy_password": "secret"
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/0.27/enterprise/integrations/datadog.md
+++ b/docs/0.27/enterprise/integrations/datadog.md
@@ -56,6 +56,39 @@ The following attributes are configured within the `{"datadog": {} }`
     "api_key": "9775a026f1ca7d1c6c5af9d94d9595a4"
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/0.27/enterprise/integrations/email.md
+++ b/docs/0.27/enterprise/integrations/email.md
@@ -164,6 +164,39 @@ The following attributes are configured within the `{"email": {} }`
     }
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/0.27/enterprise/integrations/hipchat.md
+++ b/docs/0.27/enterprise/integrations/hipchat.md
@@ -130,6 +130,39 @@ The following attributes are configured within the `{"hipchat": {} }`
     "notify": true
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/0.27/enterprise/integrations/irc.md
+++ b/docs/0.27/enterprise/integrations/irc.md
@@ -110,6 +110,39 @@ scope][2].
     "join": true
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/0.27/enterprise/integrations/jira.md
+++ b/docs/0.27/enterprise/integrations/jira.md
@@ -122,6 +122,39 @@ The following attributes are configured within the `{"jira": {} }`
     "root_url": "https://services.example.com/proxy/jira"
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/0.27/enterprise/integrations/opsgenie.md
+++ b/docs/0.27/enterprise/integrations/opsgenie.md
@@ -130,6 +130,39 @@ The following attributes are configured within the `{"opsgenie": {} }`
     "overwrites_quiet_hours": true
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/0.27/enterprise/integrations/pagerduty.md
+++ b/docs/0.27/enterprise/integrations/pagerduty.md
@@ -56,6 +56,39 @@ The following attributes are configured within the `{"pagerduty": {} }`
     "service_key": "r3FPuDvNOTEDyQYCc7trBkymIFcy2NkE"
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/0.27/enterprise/integrations/rollbar.md
+++ b/docs/0.27/enterprise/integrations/rollbar.md
@@ -80,6 +80,39 @@ The following attributes are configured within the `{"rollbar": {} }`
     "access_token_patch": "f34948101a714661a83dcd8dbe6a167a"
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/0.27/enterprise/integrations/servicenow.md
+++ b/docs/0.27/enterprise/integrations/servicenow.md
@@ -206,6 +206,39 @@ The following attributes are configured within the `{"servicenow": {} }`
     "event_table": "em_event"
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/0.27/enterprise/integrations/snmp.md
+++ b/docs/0.27/enterprise/integrations/snmp.md
@@ -110,6 +110,38 @@ The following attributes are configured within the `{"snmp": {} }`
     "community": "private"
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
 
 
 [?]:  #

--- a/docs/0.27/enterprise/integrations/victorops.md
+++ b/docs/0.27/enterprise/integrations/victorops.md
@@ -69,6 +69,39 @@ The following attributes are configured within the `{"victorops": {} }`
     "routing_key": "ops"
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/0.28/enterprise/integrations/chef.md
+++ b/docs/0.28/enterprise/integrations/chef.md
@@ -186,6 +186,39 @@ The following attributes are configured within the `{"chef": {} }`
     "proxy_password": "secret"
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/0.28/enterprise/integrations/datadog.md
+++ b/docs/0.28/enterprise/integrations/datadog.md
@@ -56,6 +56,39 @@ The following attributes are configured within the `{"datadog": {} }`
     "api_key": "9775a026f1ca7d1c6c5af9d94d9595a4"
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/0.28/enterprise/integrations/email.md
+++ b/docs/0.28/enterprise/integrations/email.md
@@ -164,6 +164,39 @@ The following attributes are configured within the `{"email": {} }`
     }
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/0.28/enterprise/integrations/hipchat.md
+++ b/docs/0.28/enterprise/integrations/hipchat.md
@@ -130,6 +130,39 @@ The following attributes are configured within the `{"hipchat": {} }`
     "notify": true
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/0.28/enterprise/integrations/irc.md
+++ b/docs/0.28/enterprise/integrations/irc.md
@@ -110,6 +110,39 @@ scope][2].
     "join": true
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/0.28/enterprise/integrations/jira.md
+++ b/docs/0.28/enterprise/integrations/jira.md
@@ -122,6 +122,39 @@ The following attributes are configured within the `{"jira": {} }`
     "root_url": "https://services.example.com/proxy/jira"
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/0.28/enterprise/integrations/opsgenie.md
+++ b/docs/0.28/enterprise/integrations/opsgenie.md
@@ -130,6 +130,39 @@ The following attributes are configured within the `{"opsgenie": {} }`
     "overwrites_quiet_hours": true
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/0.28/enterprise/integrations/pagerduty.md
+++ b/docs/0.28/enterprise/integrations/pagerduty.md
@@ -56,6 +56,39 @@ The following attributes are configured within the `{"pagerduty": {} }`
     "service_key": "r3FPuDvNOTEDyQYCc7trBkymIFcy2NkE"
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/0.28/enterprise/integrations/rollbar.md
+++ b/docs/0.28/enterprise/integrations/rollbar.md
@@ -80,6 +80,39 @@ The following attributes are configured within the `{"rollbar": {} }`
     "access_token_patch": "f34948101a714661a83dcd8dbe6a167a"
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/0.28/enterprise/integrations/servicenow.md
+++ b/docs/0.28/enterprise/integrations/servicenow.md
@@ -206,6 +206,39 @@ The following attributes are configured within the `{"servicenow": {} }`
     "event_table": "em_event"
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/0.28/enterprise/integrations/snmp.md
+++ b/docs/0.28/enterprise/integrations/snmp.md
@@ -110,6 +110,38 @@ The following attributes are configured within the `{"snmp": {} }`
     "community": "private"
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
 
 
 [?]:  #

--- a/docs/0.28/enterprise/integrations/victorops.md
+++ b/docs/0.28/enterprise/integrations/victorops.md
@@ -69,6 +69,39 @@ The following attributes are configured within the `{"victorops": {} }`
     "routing_key": "ops"
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/0.29/enterprise/integrations/chef.md
+++ b/docs/0.29/enterprise/integrations/chef.md
@@ -186,6 +186,39 @@ The following attributes are configured within the `{"chef": {} }`
     "proxy_password": "secret"
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/0.29/enterprise/integrations/datadog.md
+++ b/docs/0.29/enterprise/integrations/datadog.md
@@ -56,6 +56,39 @@ The following attributes are configured within the `{"datadog": {} }`
     "api_key": "9775a026f1ca7d1c6c5af9d94d9595a4"
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/0.29/enterprise/integrations/email.md
+++ b/docs/0.29/enterprise/integrations/email.md
@@ -164,6 +164,39 @@ The following attributes are configured within the `{"email": {} }`
     }
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/0.29/enterprise/integrations/hipchat.md
+++ b/docs/0.29/enterprise/integrations/hipchat.md
@@ -130,6 +130,39 @@ The following attributes are configured within the `{"hipchat": {} }`
     "notify": true
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/0.29/enterprise/integrations/irc.md
+++ b/docs/0.29/enterprise/integrations/irc.md
@@ -110,6 +110,39 @@ scope][2].
     "join": true
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/0.29/enterprise/integrations/jira.md
+++ b/docs/0.29/enterprise/integrations/jira.md
@@ -122,6 +122,39 @@ The following attributes are configured within the `{"jira": {} }`
     "root_url": "https://services.example.com/proxy/jira"
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/0.29/enterprise/integrations/opsgenie.md
+++ b/docs/0.29/enterprise/integrations/opsgenie.md
@@ -130,6 +130,39 @@ The following attributes are configured within the `{"opsgenie": {} }`
     "overwrites_quiet_hours": true
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/0.29/enterprise/integrations/pagerduty.md
+++ b/docs/0.29/enterprise/integrations/pagerduty.md
@@ -56,6 +56,39 @@ The following attributes are configured within the `{"pagerduty": {} }`
     "service_key": "r3FPuDvNOTEDyQYCc7trBkymIFcy2NkE"
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/0.29/enterprise/integrations/rollbar.md
+++ b/docs/0.29/enterprise/integrations/rollbar.md
@@ -80,6 +80,39 @@ The following attributes are configured within the `{"rollbar": {} }`
     "access_token_patch": "f34948101a714661a83dcd8dbe6a167a"
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/0.29/enterprise/integrations/servicenow.md
+++ b/docs/0.29/enterprise/integrations/servicenow.md
@@ -206,6 +206,39 @@ The following attributes are configured within the `{"servicenow": {} }`
     "event_table": "em_event"
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/0.29/enterprise/integrations/snmp.md
+++ b/docs/0.29/enterprise/integrations/snmp.md
@@ -110,6 +110,38 @@ The following attributes are configured within the `{"snmp": {} }`
     "community": "private"
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
 
 
 [?]:  #

--- a/docs/0.29/enterprise/integrations/victorops.md
+++ b/docs/0.29/enterprise/integrations/victorops.md
@@ -69,6 +69,39 @@ The following attributes are configured within the `{"victorops": {} }`
     "routing_key": "ops"
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/1.0/enterprise/integrations/chef.md
+++ b/docs/1.0/enterprise/integrations/chef.md
@@ -186,6 +186,39 @@ The following attributes are configured within the `{"chef": {} }`
     "proxy_password": "secret"
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/1.0/enterprise/integrations/datadog.md
+++ b/docs/1.0/enterprise/integrations/datadog.md
@@ -56,6 +56,39 @@ The following attributes are configured within the `{"datadog": {} }`
     "api_key": "9775a026f1ca7d1c6c5af9d94d9595a4"
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/1.0/enterprise/integrations/email.md
+++ b/docs/1.0/enterprise/integrations/email.md
@@ -164,6 +164,39 @@ The following attributes are configured within the `{"email": {} }`
     }
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/1.0/enterprise/integrations/hipchat.md
+++ b/docs/1.0/enterprise/integrations/hipchat.md
@@ -130,6 +130,39 @@ The following attributes are configured within the `{"hipchat": {} }`
     "notify": true
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/1.0/enterprise/integrations/irc.md
+++ b/docs/1.0/enterprise/integrations/irc.md
@@ -110,6 +110,39 @@ scope][2].
     "join": true
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/1.0/enterprise/integrations/jira.md
+++ b/docs/1.0/enterprise/integrations/jira.md
@@ -136,6 +136,39 @@ The following attributes are configured within the `{"jira": {} }`
     "root_url": "https://services.example.com/proxy/jira"
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/1.0/enterprise/integrations/opsgenie.md
+++ b/docs/1.0/enterprise/integrations/opsgenie.md
@@ -130,6 +130,39 @@ The following attributes are configured within the `{"opsgenie": {} }`
     "overwrites_quiet_hours": true
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/1.0/enterprise/integrations/pagerduty.md
+++ b/docs/1.0/enterprise/integrations/pagerduty.md
@@ -56,6 +56,39 @@ The following attributes are configured within the `{"pagerduty": {} }`
     "service_key": "r3FPuDvNOTEDyQYCc7trBkymIFcy2NkE"
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/1.0/enterprise/integrations/rollbar.md
+++ b/docs/1.0/enterprise/integrations/rollbar.md
@@ -80,6 +80,39 @@ The following attributes are configured within the `{"rollbar": {} }`
     "access_token_patch": "f34948101a714661a83dcd8dbe6a167a"
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/1.0/enterprise/integrations/servicenow.md
+++ b/docs/1.0/enterprise/integrations/servicenow.md
@@ -206,6 +206,39 @@ The following attributes are configured within the `{"servicenow": {} }`
     "event_table": "em_event"
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/1.0/enterprise/integrations/snmp.md
+++ b/docs/1.0/enterprise/integrations/snmp.md
@@ -127,6 +127,39 @@ The following attributes are configured within the `{"snmp": {} }`
     "varbind_trim": 300
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 [?]:  #
 [1]:  /enterprise
 [2]:  ../../reference/configuration.html#configuration-scopes

--- a/docs/1.0/enterprise/integrations/victorops.md
+++ b/docs/1.0/enterprise/integrations/victorops.md
@@ -69,6 +69,39 @@ The following attributes are configured within the `{"victorops": {} }`
     "routing_key": "ops"
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/1.1/enterprise/integrations/chef.md
+++ b/docs/1.1/enterprise/integrations/chef.md
@@ -186,6 +186,39 @@ The following attributes are configured within the `{"chef": {} }`
     "proxy_password": "secret"
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/1.1/enterprise/integrations/datadog.md
+++ b/docs/1.1/enterprise/integrations/datadog.md
@@ -56,6 +56,39 @@ The following attributes are configured within the `{"datadog": {} }`
     "api_key": "9775a026f1ca7d1c6c5af9d94d9595a4"
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/1.1/enterprise/integrations/email.md
+++ b/docs/1.1/enterprise/integrations/email.md
@@ -163,6 +163,38 @@ The following attributes are configured within the `{"email": {} }`
       "body": "/etc/sensu/email/body_template.erb"
     }
     ~~~
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
 
 `timeout`
 : description

--- a/docs/1.1/enterprise/integrations/hipchat.md
+++ b/docs/1.1/enterprise/integrations/hipchat.md
@@ -130,6 +130,39 @@ The following attributes are configured within the `{"hipchat": {} }`
     "notify": true
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/1.1/enterprise/integrations/irc.md
+++ b/docs/1.1/enterprise/integrations/irc.md
@@ -110,6 +110,39 @@ scope][2].
     "join": true
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/1.1/enterprise/integrations/jira.md
+++ b/docs/1.1/enterprise/integrations/jira.md
@@ -136,6 +136,39 @@ The following attributes are configured within the `{"jira": {} }`
     "root_url": "https://services.example.com/proxy/jira"
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/1.1/enterprise/integrations/opsgenie.md
+++ b/docs/1.1/enterprise/integrations/opsgenie.md
@@ -130,6 +130,39 @@ The following attributes are configured within the `{"opsgenie": {} }`
     "overwrites_quiet_hours": true
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/1.1/enterprise/integrations/pagerduty.md
+++ b/docs/1.1/enterprise/integrations/pagerduty.md
@@ -56,6 +56,39 @@ The following attributes are configured within the `{"pagerduty": {} }`
     "service_key": "r3FPuDvNOTEDyQYCc7trBkymIFcy2NkE"
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/1.1/enterprise/integrations/rollbar.md
+++ b/docs/1.1/enterprise/integrations/rollbar.md
@@ -80,6 +80,39 @@ The following attributes are configured within the `{"rollbar": {} }`
     "access_token_patch": "f34948101a714661a83dcd8dbe6a167a"
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/1.1/enterprise/integrations/servicenow.md
+++ b/docs/1.1/enterprise/integrations/servicenow.md
@@ -206,6 +206,39 @@ The following attributes are configured within the `{"servicenow": {} }`
     "event_table": "em_event"
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/1.1/enterprise/integrations/snmp.md
+++ b/docs/1.1/enterprise/integrations/snmp.md
@@ -127,6 +127,39 @@ The following attributes are configured within the `{"snmp": {} }`
     "varbind_trim": 300
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 [?]:  #
 [1]:  /enterprise
 [2]:  ../../reference/configuration.html#configuration-scopes

--- a/docs/1.1/enterprise/integrations/victorops.md
+++ b/docs/1.1/enterprise/integrations/victorops.md
@@ -69,6 +69,39 @@ The following attributes are configured within the `{"victorops": {} }`
     "routing_key": "ops"
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/1.2/enterprise/integrations/chef.md
+++ b/docs/1.2/enterprise/integrations/chef.md
@@ -186,6 +186,39 @@ The following attributes are configured within the `{"chef": {} }`
     "proxy_password": "secret"
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/1.2/enterprise/integrations/datadog.md
+++ b/docs/1.2/enterprise/integrations/datadog.md
@@ -56,6 +56,39 @@ The following attributes are configured within the `{"datadog": {} }`
     "api_key": "9775a026f1ca7d1c6c5af9d94d9595a4"
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/1.2/enterprise/integrations/email.md
+++ b/docs/1.2/enterprise/integrations/email.md
@@ -178,6 +178,38 @@ The following attributes are configured within the `{"email": {} }`
       "body": "/etc/sensu/email/body_template.erb"
     }
     ~~~
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
 
 `timeout`
 : description

--- a/docs/1.2/enterprise/integrations/hipchat.md
+++ b/docs/1.2/enterprise/integrations/hipchat.md
@@ -130,6 +130,39 @@ The following attributes are configured within the `{"hipchat": {} }`
     "notify": true
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/1.2/enterprise/integrations/irc.md
+++ b/docs/1.2/enterprise/integrations/irc.md
@@ -110,6 +110,39 @@ scope][2].
     "join": true
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/1.2/enterprise/integrations/jira.md
+++ b/docs/1.2/enterprise/integrations/jira.md
@@ -136,6 +136,39 @@ The following attributes are configured within the `{"jira": {} }`
     "root_url": "https://services.example.com/proxy/jira"
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/1.2/enterprise/integrations/opsgenie.md
+++ b/docs/1.2/enterprise/integrations/opsgenie.md
@@ -130,6 +130,39 @@ The following attributes are configured within the `{"opsgenie": {} }`
     "overwrites_quiet_hours": true
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/1.2/enterprise/integrations/pagerduty.md
+++ b/docs/1.2/enterprise/integrations/pagerduty.md
@@ -56,6 +56,39 @@ The following attributes are configured within the `{"pagerduty": {} }`
     "service_key": "r3FPuDvNOTEDyQYCc7trBkymIFcy2NkE"
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/1.2/enterprise/integrations/rollbar.md
+++ b/docs/1.2/enterprise/integrations/rollbar.md
@@ -80,6 +80,39 @@ The following attributes are configured within the `{"rollbar": {} }`
     "access_token_patch": "f34948101a714661a83dcd8dbe6a167a"
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/1.2/enterprise/integrations/servicenow.md
+++ b/docs/1.2/enterprise/integrations/servicenow.md
@@ -206,6 +206,39 @@ The following attributes are configured within the `{"servicenow": {} }`
     "event_table": "em_event"
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/1.2/enterprise/integrations/slack.md
+++ b/docs/1.2/enterprise/integrations/slack.md
@@ -114,6 +114,39 @@ The following attributes are configured within the `{"slack": {} }`
     }
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).

--- a/docs/1.2/enterprise/integrations/snmp.md
+++ b/docs/1.2/enterprise/integrations/snmp.md
@@ -127,6 +127,39 @@ The following attributes are configured within the `{"snmp": {} }`
     "varbind_trim": 300
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 [?]:  #
 [1]:  /enterprise
 [2]:  ../../reference/configuration.html#configuration-scopes

--- a/docs/1.2/enterprise/integrations/victorops.md
+++ b/docs/1.2/enterprise/integrations/victorops.md
@@ -69,6 +69,39 @@ The following attributes are configured within the `{"victorops": {} }`
     "routing_key": "ops"
     ~~~
 
+`filters`
+: description
+  : An array of Sensu event filters (names) to use when filtering events for the
+    handler. Each array item must be a string. Specified filters are merged with
+    default values.
+: required
+  : false
+: type
+  : Array
+: default
+  : ~~~ shell
+    ["handle_when", "check_dependencies"]
+    ~~~
+: example
+  : ~~~ shell
+    "filters": ["recurrence", "production"]
+    ~~~
+
+`severities`
+: description
+  : An array of check result severities the handler will handle.
+    _NOTE: event resolution bypasses this filtering._
+: required
+  : false
+: type
+  : Array
+: allowed values
+  : `ok`, `warning`, `critical`, `unknown`
+: example
+  : ~~~ shell
+    "severities": ["critical", "unknown"]
+    ~~~
+
 `timeout`
 : description
   : The handler execution duration timeout in seconds (hard stop).


### PR DESCRIPTION
Periodically customers ask about support for `severities` and `filters` attributes on Sensu Enterprise integrations. These attributes are supported on notification integrations, but until now this fact has not been documented.